### PR TITLE
feat: Phase 1 미니 SQL 파서 구조 및 테스트 기반 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - "feat-*"
+      - "fix-*"
+      - "refactor-*"
+      - "docs-*"
+      - "test-*"
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  linux-build-and-test:
+    name: Linux (${{ matrix.compiler }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+          - gcc
+          - clang
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y make gcc clang
+
+      - name: Build binaries
+        run: make clean all CC=${{ matrix.compiler }}
+
+      - name: Run parser tests
+        run: make test CC=${{ matrix.compiler }}
+
+      - name: Run sample INSERT query
+        run: ./sql_processor queries/insert_users.sql
+
+      - name: Run sample SELECT query
+        run: ./sql_processor queries/select_users.sql
+
+  windows-build-and-test:
+    name: Windows (MinGW)
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up MSYS2 toolchain
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            make
+            mingw-w64-x86_64-gcc
+
+      - name: Build binaries
+        run: make clean all
+
+      - name: Run parser tests
+        run: make test
+
+      - name: Run sample INSERT query
+        run: ./sql_processor queries/insert_users.sql
+
+      - name: Run sample SELECT query
+        run: ./sql_processor queries/select_users.sql

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,132 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-release-assets:
+    name: Build Release Asset (${{ matrix.target }})
+    runs-on: ${{ matrix.runs_on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-x86_64
+            runs_on: ubuntu-latest
+          - target: windows-x86_64
+            runs_on: windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set release version
+        id: version
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            echo "value=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=manual-${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Linux build tools
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y make gcc tar
+
+      - name: Build on Linux
+        if: runner.os == 'Linux'
+        run: make clean all
+
+      - name: Package Linux artifact
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          asset="sql-processor-${{ steps.version.outputs.value }}-linux-x86_64"
+          package_dir="${asset}"
+          mkdir -p "${package_dir}"
+          cp sql_processor "${package_dir}/"
+          cp README.md "${package_dir}/"
+          cp -R queries "${package_dir}/"
+          cp -R data "${package_dir}/"
+          tar -czf "${asset}.tar.gz" "${package_dir}"
+
+      - name: Upload Linux artifact
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: sql-processor-${{ steps.version.outputs.value }}-linux-x86_64
+          path: sql-processor-${{ steps.version.outputs.value }}-linux-x86_64.tar.gz
+
+      - name: Set up MSYS2 toolchain
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            make
+            mingw-w64-x86_64-gcc
+
+      - name: Build on Windows
+        if: runner.os == 'Windows'
+        shell: msys2 {0}
+        run: make clean all
+
+      - name: Package Windows artifact
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $asset = "sql-processor-${{ steps.version.outputs.value }}-windows-x86_64"
+          $packageDir = Join-Path $PWD $asset
+          New-Item -ItemType Directory -Force $packageDir | Out-Null
+          Copy-Item "$PWD\\sql_processor.exe" -Destination $packageDir
+          Copy-Item "$PWD\\README.md" -Destination $packageDir
+          Copy-Item "$PWD\\queries" -Destination $packageDir -Recurse
+          Copy-Item "$PWD\\data" -Destination $packageDir -Recurse
+          Compress-Archive -Path "$packageDir\\*" -DestinationPath "$PWD\\$asset.zip" -Force
+
+      - name: Upload Windows artifact
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: sql-processor-${{ steps.version.outputs.value }}-windows-x86_64
+          path: sql-processor-${{ steps.version.outputs.value }}-windows-x86_64.zip
+
+  publish-release:
+    name: Publish GitHub Release
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build-release-assets
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download release assets
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: Create or update release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          mapfile -t files < <(find dist -type f | sort)
+          if [[ "${#files[@]}" -eq 0 ]]; then
+            echo "No release assets were downloaded."
+            exit 1
+          fi
+
+          if gh release view "${tag}" >/dev/null 2>&1; then
+            gh release upload "${tag}" "${files[@]}" --clobber
+          else
+            gh release create "${tag}" "${files[@]}" --title "${tag}" --generate-notes
+          fi

--- a/Agents.md
+++ b/Agents.md
@@ -1,0 +1,86 @@
+# Agents Memory
+
+## Project Requirements
+- Language: C (C11 baseline)
+- CLI entry: `./sql_processor <sql_file> [data_dir]`
+- Read exactly one SQL statement from a file, parse it, and execute it later
+- Project layout: `src/`, `include/`, `tests/`, `data/`, `queries/`, `Makefile`
+
+## Required Interfaces
+- `parse_sql(const char *sql, Statement *out, SqlError *err)`
+- `execute_statement(const Statement *stmt, const char *data_dir, FILE *out, SqlError *err)`
+- `storage_append_row(...)`
+
+## MVP Grammar
+- `INSERT INTO [schema.]table VALUES (...);`
+- `SELECT * FROM [schema.]table;`
+- Strings use single quotes
+- Numbers are integers only
+- No `WHERE`, no column list, no multiple statements
+- Mixed-case keywords and flexible whitespace/newlines must be supported
+
+## Storage Rules
+- CSV only
+- Header already exists
+- `table` maps to `table.csv`
+- `schema.table` maps to `schema__table.csv`
+- Files live under `data/`
+
+## Demo Data / Queries
+- Demo CSV: `users.csv`
+- Demo insert: `INSERT INTO users VALUES (1, 'alice', 20);`
+- Demo select: `SELECT * FROM users;`
+
+## Action Plan
+
+### Phase 1 - CLI and Parser
+- [x] Create project directories and `Makefile`
+- [x] Implement CLI entrypoint and argument handling
+- [x] Define `SqlError` and `Statement` in `include/`
+- [x] Implement `parse_sql`
+- [x] Add parser unit tests
+
+### Phase 2 - Executor and Storage
+- [ ] Implement storage module and `storage_append_row`
+- [ ] Implement executor and `execute_statement`
+- [ ] Integrate CLI -> Parser -> Executor -> Storage
+- [ ] Add integration and edge case tests
+
+## Current Status Checklist
+- [x] Initial repository inspection completed
+- [x] Phase plan drafted
+- [x] Agents.md created and synced during implementation
+- [x] Phase 1 implementation completed
+- [x] Phase 1 review completed
+- [x] Post-review structure refactor completed
+- [ ] User approved Phase 2 start
+
+## Architecture Decisions
+- Phase 1 only for now. Do not implement Phase 2 behavior until the user explicitly approves moving on after review.
+- Parser uses a manual scanner, not `strtok`.
+- AST uses heap-owned strings and value arrays.
+- Add `statement_init` and `statement_free` helper APIs for deterministic cleanup.
+- Error reporting uses `int` return code with `out` and `err` output parameters.
+- Baseline build target is WSL/Linux with `make`, but code should remain portable C11.
+- `parse_sql` builds a temporary `Statement` and only transfers ownership to the caller on success.
+- Phase 1 CLI reads the SQL file, parses it, and prints an AST summary instead of executing storage logic.
+- String literals do not support quote escaping in MVP.
+- Public headers are split by concern, while `include/sql_processor.h` remains as a convenience umbrella include.
+- Phase 2 boundaries are compiled as explicit stubs so the link graph already reflects the intended architecture.
+
+## Context Notes
+- Current Windows shell does not have `gcc`, `clang`, or `make` on PATH.
+- `cmake` exists, but the project contract remains `Makefile`.
+- `git status` is currently blocked by Git safe-directory ownership settings, so avoid relying on git commands unless needed.
+- `bash.exe` and `wsl.exe` access are currently blocked by service permission errors, so local `make test` verification could not be executed from this shell.
+- Demo assets were created: `data/users.csv`, `queries/insert_users.sql`, `queries/select_users.sql`.
+- Phase 1 rationale and implementation flow document added: `PHASE1_IMPLEMENTATION_NOTES.md`.
+- `PHASE1_IMPLEMENTATION_NOTES.md` includes code review focus areas; some exact line mappings now predate the post-review refactor.
+
+## Review Log
+- Phase 1 code implemented: project skeleton, CLI, AST types, parser, and parser tests.
+- Verification status: static review completed, compile/runtime verification blocked by missing compiler toolchain in the current shell.
+- Documentation added: step-by-step implementation rationale and review notes in `PHASE1_IMPLEMENTATION_NOTES.md`.
+- Documentation refined: review checkpoints now point to exact source files and line ranges.
+- Post-review refactor applied: split headers by module and added `execute` / `storage` stub modules without changing Phase 1 scope.
+- Pending: explain Phase 1 internals, review with the user, and wait for explicit approval before any Phase 2 code.

--- a/Agents.md
+++ b/Agents.md
@@ -1,86 +1,97 @@
 # Agents Memory
 
-## Project Requirements
-- Language: C (C11 baseline)
-- CLI entry: `./sql_processor <sql_file> [data_dir]`
-- Read exactly one SQL statement from a file, parse it, and execute it later
-- Project layout: `src/`, `include/`, `tests/`, `data/`, `queries/`, `Makefile`
+## 프로젝트 요구사항
 
-## Required Interfaces
+- 언어: C (C11 기준)
+- CLI 진입점: `./sql_processor <sql_file> [data_dir]`
+- SQL 파일에서 문장 하나를 읽고 파싱한 뒤, 이후 단계에서 실행할 수 있어야 함
+- 프로젝트 구조: `src/`, `include/`, `tests/`, `data/`, `queries/`, `Makefile`
+
+## 필수 인터페이스
+
 - `parse_sql(const char *sql, Statement *out, SqlError *err)`
 - `execute_statement(const Statement *stmt, const char *data_dir, FILE *out, SqlError *err)`
 - `storage_append_row(...)`
 
-## MVP Grammar
+## MVP 문법
+
 - `INSERT INTO [schema.]table VALUES (...);`
 - `SELECT * FROM [schema.]table;`
-- Strings use single quotes
-- Numbers are integers only
-- No `WHERE`, no column list, no multiple statements
-- Mixed-case keywords and flexible whitespace/newlines must be supported
+- 문자열은 작은따옴표 사용
+- 숫자는 정수만 지원
+- `WHERE`, 컬럼 목록, 다중 문장은 지원하지 않음
+- 키워드는 대소문자를 구분하지 않고, 공백과 개행을 유연하게 허용해야 함
 
-## Storage Rules
-- CSV only
-- Header already exists
-- `table` maps to `table.csv`
-- `schema.table` maps to `schema__table.csv`
-- Files live under `data/`
+## 저장소 규칙
 
-## Demo Data / Queries
-- Demo CSV: `users.csv`
-- Demo insert: `INSERT INTO users VALUES (1, 'alice', 20);`
-- Demo select: `SELECT * FROM users;`
+- CSV만 사용
+- 헤더는 이미 존재한다고 가정
+- `table`은 `table.csv`로 매핑
+- `schema.table`은 `schema__table.csv`로 매핑
+- 파일은 `data/` 아래에 위치
 
-## Action Plan
+## 데모 데이터 / 쿼리
 
-### Phase 1 - CLI and Parser
-- [x] Create project directories and `Makefile`
-- [x] Implement CLI entrypoint and argument handling
-- [x] Define `SqlError` and `Statement` in `include/`
-- [x] Implement `parse_sql`
-- [x] Add parser unit tests
+- 데모 CSV: `users.csv`
+- 데모 INSERT: `INSERT INTO users VALUES (1, 'alice', 20);`
+- 데모 SELECT: `SELECT * FROM users;`
 
-### Phase 2 - Executor and Storage
-- [ ] Implement storage module and `storage_append_row`
-- [ ] Implement executor and `execute_statement`
-- [ ] Integrate CLI -> Parser -> Executor -> Storage
-- [ ] Add integration and edge case tests
+## 작업 계획
 
-## Current Status Checklist
-- [x] Initial repository inspection completed
-- [x] Phase plan drafted
-- [x] Agents.md created and synced during implementation
-- [x] Phase 1 implementation completed
-- [x] Phase 1 review completed
-- [x] Post-review structure refactor completed
-- [ ] User approved Phase 2 start
+### Phase 1 - CLI와 파서
 
-## Architecture Decisions
-- Phase 1 only for now. Do not implement Phase 2 behavior until the user explicitly approves moving on after review.
-- Parser uses a manual scanner, not `strtok`.
-- AST uses heap-owned strings and value arrays.
-- Add `statement_init` and `statement_free` helper APIs for deterministic cleanup.
-- Error reporting uses `int` return code with `out` and `err` output parameters.
-- Baseline build target is WSL/Linux with `make`, but code should remain portable C11.
-- `parse_sql` builds a temporary `Statement` and only transfers ownership to the caller on success.
-- Phase 1 CLI reads the SQL file, parses it, and prints an AST summary instead of executing storage logic.
-- String literals do not support quote escaping in MVP.
-- Public headers are split by concern, while `include/sql_processor.h` remains as a convenience umbrella include.
-- Phase 2 boundaries are compiled as explicit stubs so the link graph already reflects the intended architecture.
+- [x] 프로젝트 디렉터리와 `Makefile` 생성
+- [x] CLI 진입점과 인자 처리 구현
+- [x] `include/`에 `SqlError`, `Statement` 정의
+- [x] `parse_sql` 구현
+- [x] parser 단위 테스트 추가
 
-## Context Notes
-- Current Windows shell does not have `gcc`, `clang`, or `make` on PATH.
-- `cmake` exists, but the project contract remains `Makefile`.
-- `git status` is currently blocked by Git safe-directory ownership settings, so avoid relying on git commands unless needed.
-- `bash.exe` and `wsl.exe` access are currently blocked by service permission errors, so local `make test` verification could not be executed from this shell.
-- Demo assets were created: `data/users.csv`, `queries/insert_users.sql`, `queries/select_users.sql`.
-- Phase 1 rationale and implementation flow document added: `PHASE1_IMPLEMENTATION_NOTES.md`.
-- `PHASE1_IMPLEMENTATION_NOTES.md` includes code review focus areas; some exact line mappings now predate the post-review refactor.
+### Phase 2 - 실행기와 저장소
 
-## Review Log
-- Phase 1 code implemented: project skeleton, CLI, AST types, parser, and parser tests.
-- Verification status: static review completed, compile/runtime verification blocked by missing compiler toolchain in the current shell.
-- Documentation added: step-by-step implementation rationale and review notes in `PHASE1_IMPLEMENTATION_NOTES.md`.
-- Documentation refined: review checkpoints now point to exact source files and line ranges.
-- Post-review refactor applied: split headers by module and added `execute` / `storage` stub modules without changing Phase 1 scope.
-- Pending: explain Phase 1 internals, review with the user, and wait for explicit approval before any Phase 2 code.
+- [ ] 저장소 모듈과 `storage_append_row` 구현
+- [ ] 실행기와 `execute_statement` 구현
+- [ ] CLI -> Parser -> Executor -> Storage 통합
+- [ ] 통합 테스트와 경계 케이스 테스트 추가
+
+## 현재 상태 체크리스트
+
+- [x] 초기 저장소 확인 완료
+- [x] 단계별 계획 작성 완료
+- [x] 구현 중 `Agents.md` 생성 및 동기화 완료
+- [x] Phase 1 구현 완료
+- [x] Phase 1 리뷰 완료
+- [x] 리뷰 후 구조 리팩터링 완료
+- [ ] 사용자 승인 후 Phase 2 시작 예정
+
+## 아키텍처 결정
+
+- 지금은 Phase 1까지만 다룸. 사용자가 명시적으로 승인하기 전에는 Phase 2 동작을 구현하지 않음.
+- 파서는 `strtok` 대신 수동 스캐너를 사용함.
+- AST는 힙에 할당된 문자열과 값 배열을 사용함.
+- 예측 가능한 정리를 위해 `statement_init`, `statement_free`를 제공함.
+- 에러는 `int` 반환값과 `out` / `err` 출력 파라미터 조합으로 전달함.
+- 기본 빌드 기준은 WSL/Linux `make`지만, 코드는 가능한 한 portable C11로 유지함.
+- `parse_sql`은 임시 `Statement`를 먼저 만든 뒤 성공 시에만 호출자에게 소유권을 넘김.
+- Phase 1 CLI는 파일을 읽고 파싱 결과 요약만 출력하며, 저장소 실행은 하지 않음.
+- MVP에서는 문자열 escape를 지원하지 않음.
+- 공개 헤더는 역할별로 나누고, `include/sql_processor.h`는 편의용 우산 헤더로 유지함.
+- Phase 2 경계는 실제 링크 구조에 드러나도록 스텁 모듈로 분리해 둠.
+
+## 컨텍스트 메모
+
+- 현재 Windows 셸에는 `gcc`, `clang`, `make`가 PATH에 없음.
+- `cmake`는 있지만 프로젝트 계약은 여전히 `Makefile` 기준임.
+- 과거에는 `git safe.directory` 설정이 없어 Git 명령이 막혔음.
+- `bash.exe`, `wsl.exe`는 권한 문제로 로컬 `make test` 검증에 바로 쓰기 어려웠음.
+- 데모 자산으로 `data/users.csv`, `queries/insert_users.sql`, `queries/select_users.sql`를 추가함.
+- Phase 1 구현 배경과 리뷰 포인트는 `PHASE1_IMPLEMENTATION_NOTES.md`에 정리함.
+- `PHASE1_IMPLEMENTATION_NOTES.md`의 일부 라인 번호 기반 설명은 리팩터링 이전 기준일 수 있음.
+
+## 리뷰 로그
+
+- Phase 1 코드 구현 완료: 프로젝트 뼈대, CLI, AST 타입, parser, parser 테스트
+- 정적 리뷰 완료
+- 로컬 빌드/실행 검증은 툴체인 제약 때문에 한동안 보류됐지만, 이후 Windows Dev-Cpp MinGW 기준 직접 검증 완료
+- `PHASE1_IMPLEMENTATION_NOTES.md`에 구현 배경과 리뷰 포인트 문서화 완료
+- 리뷰 후 헤더 역할 분리, `execute` / `storage` 스텁 모듈 추가 완료
+- 현재 PR 브랜치에는 GitHub Actions 기반 CI/CD도 추가됨

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+CC ?= gcc
+CFLAGS ?= -std=c11 -Wall -Wextra -Wpedantic -Iinclude -g
+
+TARGET := sql_processor
+CORE_OBJS := src/parser.o src/statement.o src/sql_error.o
+PHASE2_STUB_OBJS := src/execute_stub.o src/storage_stub.o
+APP_OBJS := src/main.o $(CORE_OBJS) $(PHASE2_STUB_OBJS)
+TEST_OBJS := tests/test_parser.o $(CORE_OBJS)
+TEST_TARGET := test_parser
+
+.PHONY: all test clean
+
+all: $(TARGET) $(TEST_TARGET)
+
+$(TARGET): $(APP_OBJS)
+	$(CC) $(CFLAGS) -o $@ $(APP_OBJS)
+
+$(TEST_TARGET): $(TEST_OBJS)
+	$(CC) $(CFLAGS) -o $@ $(TEST_OBJS)
+
+src/%.o: src/%.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+tests/%.o: tests/%.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+test: $(TEST_TARGET)
+	./$(TEST_TARGET)
+
+clean:
+	rm -f $(TARGET) $(TEST_TARGET) src/*.o tests/*.o

--- a/PHASE1_IMPLEMENTATION_NOTES.md
+++ b/PHASE1_IMPLEMENTATION_NOTES.md
@@ -1,396 +1,294 @@
-# Phase 1 Implementation Notes
+# Phase 1 구현 노트
 
-## Purpose
-- This document does not expose a raw internal thought log.
-- It records the shareable engineering rationale, implementation order, and review points for Phase 1.
-- Scope is limited to CLI setup and SQL parsing. Executor and storage are intentionally excluded.
+## 목적
 
-## Phase 1 Goal
-- Read one SQL file.
-- Accept exactly one SQL statement per file.
-- Support:
+- 이 문서는 내부 사고 과정을 그대로 드러내는 용도가 아닙니다.
+- Phase 1에서 공유 가능한 설계 이유, 구현 순서, 리뷰 포인트를 정리합니다.
+- 범위는 CLI 구성과 SQL 파싱까지로 제한합니다.
+- 실행기와 저장소는 의도적으로 Phase 2에 남겨 둡니다.
+
+## Phase 1 목표
+
+- SQL 파일 하나를 읽는다.
+- 파일당 SQL 문장 하나만 허용한다.
+- 아래 문법을 지원한다.
   - `INSERT INTO [schema.]table VALUES (...);`
   - `SELECT * FROM [schema.]table;`
-- Convert the SQL text into a `Statement` AST.
-- Stop at parsing in Phase 1. Do not execute storage logic yet.
+- SQL 텍스트를 `Statement` AST로 변환한다.
+- Phase 1에서는 파싱까지만 수행하고 저장소 실행은 하지 않는다.
 
-## 1. Initial Grounding
-- Confirmed the repository was nearly empty.
-- Created `Agents.md` first and used it as persistent project memory.
-- From that point on, the working rule became:
-  - read `Agents.md` before major work,
-  - update it after design decisions or task completion.
+## 1. 초기 판단
 
-## 2. Environment Facts Found First
-- The current PowerShell environment does not have `gcc`, `clang`, or `make` on PATH.
-- `cmake` exists, but the project contract is still `Makefile`.
-- `bash.exe` and `wsl.exe` are blocked by permission errors in this shell.
-- Result:
-  - code was written to portable C11 assumptions,
-  - runtime compile verification could not be completed from this shell,
-  - this status was recorded in `Agents.md`.
+- 저장소가 거의 비어 있는 상태라는 점을 먼저 확인했다.
+- 작업 중 지속적으로 참조할 문서로 `Agents.md`를 먼저 만들었다.
+- 이후 작업 규칙은 다음과 같이 정리했다.
+  1. 큰 작업 전에 `Agents.md`를 읽는다.
+  2. 설계 결정이나 상태 변화가 생기면 `Agents.md`를 갱신한다.
 
-## 3. Why the Implementation Started with Headers
-- The user already fixed the public interfaces.
-- Because of that, the safest order was:
-  1. define shared types and function declarations,
-  2. define ownership and cleanup rules,
-  3. build the parser on top of those rules,
-  4. build the CLI around the parser,
-  5. add tests around the parser contract.
+## 2. 먼저 확인한 환경 정보
 
-## 4. Shared Type Design
+- 현재 PowerShell 환경에는 `gcc`, `clang`, `make`가 PATH에 없다.
+- `cmake`는 존재하지만 프로젝트 계약은 `Makefile` 기준이다.
+- `bash.exe`, `wsl.exe`는 권한 문제로 바로 사용하기 어렵다.
+
+따라서 다음 원칙을 잡았다.
+
+- 코드는 portable C11 기준으로 작성한다.
+- 현재 셸에서는 컴파일 검증이 막힐 수 있음을 문서에 남긴다.
+- 환경 이슈도 구현 결과의 일부로 기록한다.
+
+## 3. 왜 헤더부터 시작했는가
+
+사용자가 이미 공개 인터페이스 방향을 정한 상태였기 때문에, 가장 안전한 순서는 다음과 같았다.
+
+1. 공통 타입과 함수 선언 정리
+2. 메모리 소유권과 정리 규칙 정의
+3. 그 규칙 위에 파서 구현
+4. CLI를 파서 위에 연결
+5. 테스트로 계약을 고정
+
+## 4. 공통 타입 설계
 
 ### `SqlError`
-- C has no exception system.
-- A plain integer return value is not enough for useful debugging.
-- `SqlError` stores:
+
+- C에는 예외 시스템이 없다.
+- 단순한 정수 반환값만으로는 디버깅 정보가 부족하다.
+- 그래서 `SqlError`는 아래 정보를 가진다.
   - `code`
   - `position`
   - `message`
-- This makes parser failures observable and reviewable.
+
+이 구조 덕분에 “왜 실패했는지”와 “어디에서 실패했는지”를 함께 볼 수 있다.
 
 ### `Statement`
-- MVP only needs two statement kinds:
+
+- MVP에서는 두 종류의 문장만 필요하다.
   - `STMT_INSERT`
   - `STMT_SELECT`
-- Common fields:
+- 공통 필드는 다음과 같다.
   - `type`
   - `schema`
   - `table`
-- Insert-specific payload:
+- `INSERT` 전용 데이터는 다음과 같다.
   - `values`
   - `value_count`
-- `SELECT *` needs no column list in Phase 1.
+
+`SELECT *`만 지원하므로 Phase 1에서는 컬럼 목록 구조가 필요 없다.
 
 ### `SqlValue`
-- Values are either integers or strings.
-- A tagged union was chosen:
-  - `type` tells which variant is active,
-  - the union stores the actual payload.
-- This keeps the representation compact and reusable for Phase 2 CSV output.
 
-## 5. Memory Ownership Strategy
-- The first critical C design question was ownership.
-- The chosen rule is heap-owned AST data:
-  - parser deep-copies identifiers and string literals,
-  - parser allocates the `values` array,
-  - caller owns the successful `Statement`,
-  - caller must release it with `statement_free`.
+- 값은 정수 또는 문자열 두 종류만 지원한다.
+- 그래서 tagged union 형태를 사용했다.
+  - `type`이 현재 값 종류를 나타낸다.
+  - union이 실제 payload를 저장한다.
 
-### Why this strategy
-- AST lifetime is decoupled from the input SQL buffer lifetime.
-- The CLI can free the original file buffer without invalidating the AST.
-- Tests stay simple because they do not depend on input string lifetime.
+이 구조는 메모리를 낭비하지 않으면서도 Phase 2 CSV 출력으로 이어가기 쉽다.
 
-### Success and failure behavior
-- On success:
-  - `out` receives ownership of all heap data.
-- On failure:
-  - the parser frees all partially built allocations before returning.
-- This keeps the caller from dealing with partially initialized cleanup.
+## 5. 메모리 소유권 전략
 
-## 6. Why a Manual Scanner Was Chosen Instead of `strtok`
-- SQL parsing needs context-sensitive control over:
-  - whitespace,
-  - punctuation,
-  - keywords,
-  - quoted strings,
-  - exact error position.
-- `strtok` was rejected because it:
-  - mutates the input buffer,
-  - makes position tracking harder,
-  - handles quoted strings poorly,
-  - is awkward for tokens like `.`, `(`, `)`, `,`, `;`.
-- A manual scanner was used instead:
-  - `Parser { input, length, pos }`
-  - helper functions inspect and advance one region at a time.
+이 프로젝트에서 가장 중요한 C 설계 포인트는 소유권이다.
 
-## 7. Parser Construction Order
+선택한 규칙은 “파서가 AST를 힙에 완전히 구성하고, 성공 시 호출자가 소유권을 갖는다”이다.
 
-### 7-1. Minimal scanner helpers
+- 파서는 식별자와 문자열 리터럴을 deep copy 한다.
+- 파서는 `values` 배열을 할당한다.
+- 성공한 `Statement`의 소유자는 호출자다.
+- 호출자는 `statement_free`로 정리해야 한다.
+
+### 이 전략의 장점
+
+- AST 수명이 원본 SQL 버퍼 수명에 묶이지 않는다.
+- CLI는 파싱 뒤 원본 파일 버퍼를 바로 해제할 수 있다.
+- 테스트도 입력 문자열의 생존 기간을 신경 쓰지 않아도 된다.
+
+### 성공과 실패 시 동작
+
+- 성공 시
+  - `out`이 전체 AST 소유권을 받는다.
+- 실패 시
+  - 파서가 부분적으로 만든 할당도 내부에서 정리한다.
+
+즉, 호출자는 실패한 `Statement`의 중간 상태를 복구할 필요가 없다.
+
+## 6. 왜 `strtok` 대신 수동 스캐너를 썼는가
+
+SQL 파싱은 다음 요소를 세밀하게 다뤄야 한다.
+
+- 공백
+- 문장 부호
+- 키워드
+- 따옴표 문자열
+- 정확한 에러 위치
+
+`strtok`는 이 작업에 맞지 않았다.
+
+- 입력 버퍼를 직접 변경한다.
+- 위치 추적이 어렵다.
+- quoted string 처리에 약하다.
+- `.`, `(`, `)`, `,`, `;` 같은 문자를 다루기 불편하다.
+
+그래서 다음 구조의 수동 스캐너를 사용했다.
+
+- `Parser { input, length, pos }`
+- 보조 함수들이 현재 위치를 검사하고 조금씩 전진한다.
+
+## 7. 파서 구현 순서
+
+### 7-1. 최소 스캐너 헬퍼
+
+먼저 다음 함수들을 만들었다.
+
 - `current_char`
 - `skip_whitespace`
 - `copy_substring`
 - `match_keyword`
 - `expect_keyword`
 
-These functions define the basic "read at current position, then advance" model.
+이 함수들이 “현재 위치를 읽고, 필요하면 앞으로 전진한다”는 기본 모델을 만든다.
 
-### 7-2. Identifier parsing
-- `parse_identifier` accepts `[A-Za-z_]` followed by `[A-Za-z0-9_]*`.
-- `parse_qualified_name` reads either:
+### 7-2. 식별자 파싱
+
+- `parse_identifier`는 `[A-Za-z_]`로 시작하고 뒤에 `[A-Za-z0-9_]*`가 오는 이름을 읽는다.
+- `parse_qualified_name`은 아래 둘 중 하나를 읽는다.
   - `table`
   - `schema.table`
 
-### 7-3. Literal parsing
-- Integer literals use `strtoll`.
-- String literals copy the content between single quotes.
-- Quote escaping is intentionally not supported in MVP.
+### 7-3. 리터럴 파싱
 
-### 7-4. VALUES list parsing
-- Confirm `(`.
-- Parse one value.
-- Repeatedly accept either:
-  - `,` and another value,
-  - `)` to finish.
-- Empty `()` is rejected in MVP.
+- 정수는 `strtoll`로 처리한다.
+- 문자열은 작은따옴표 사이 내용을 복사한다.
+- MVP에서는 문자열 escape를 지원하지 않는다.
 
-### 7-5. Statement parsing
-- `INSERT` path:
-  - `INTO`
-  - target table
-  - `VALUES`
-  - values list
-- `SELECT` path:
-  - `*`
-  - `FROM`
-  - target table
+### 7-4. VALUES 리스트 파싱
 
-### 7-6. Statement termination
-- Require a final `;`.
-- Allow only trailing whitespace after `;`.
-- This enforces the "one statement per file" rule.
+동작 순서는 다음과 같다.
 
-## 8. Why `parse_sql` Uses a Temporary Local `Statement`
-- `parse_sql` builds a local `Statement stmt` first.
-- If parsing fails halfway, that local object can be cleaned safely.
-- Only on success does the function transfer it with `*out = stmt`.
-- This avoids leaving the caller with a half-built object.
+1. `(` 확인
+2. 값 하나 파싱
+3. 이후에는 아래 둘 중 하나만 허용
+   - `,` 다음 또 다른 값
+   - `)` 로 종료
 
-## 9. CLI Construction
-- `main.c` was intentionally kept small in Phase 1.
-- Execution order:
-  1. validate CLI arguments,
-  2. read the SQL file into memory,
-  3. call `parse_sql`,
-  4. print a normalized AST summary on success,
-  5. print code, position, and message on failure.
-- `execute_statement` is not called yet by design.
+빈 `()`는 MVP에서 허용하지 않는다.
 
-## 10. Test Construction
-- Tests were written as a single C executable without external frameworks.
-- Reasons:
-  - minimal dependency surface,
-  - easy to compile in a basic C environment,
-  - each test also documents one parser behavior.
+### 7-5. 문장 파싱
 
-### Success cases added
-- simple insert
-- simple select
-- qualified schema name
-- mixed case keywords
-- extra whitespace and newlines
-- negative integer
+`INSERT` 경로는 다음 순서다.
 
-### Failure cases added
-- missing semicolon
-- column list in select
-- unterminated string
-- multiple statements
-- where clause usage
+- `INTO`
+- 대상 테이블
+- `VALUES`
+- 값 목록
 
-## 11. Ongoing Design Rules During Implementation
-- Keep Phase 1 focused on parsing only.
-- Keep ownership explicit.
-- Record error positions as close to the actual fault as possible.
-- Do not silently expand beyond the MVP grammar.
-- Do not mix executor or storage behavior into the parser phase.
+`SELECT` 경로는 다음 순서다.
 
-## 12. Intentional Non-Features in Phase 1
-- no string escape support
-- no floating point numbers
-- no `WHERE`
-- no column selection
-- no multiple statements
-- no CSV read/write execution
-- no implementation yet for:
+- `*`
+- `FROM`
+- 대상 테이블
+
+### 7-6. 문장 종료 처리
+
+- 마지막 `;`를 반드시 요구한다.
+- `;` 뒤에는 trailing whitespace만 허용한다.
+
+이렇게 해서 “파일당 문장 하나” 규칙을 강제한다.
+
+## 8. 왜 `parse_sql`이 임시 `Statement`를 쓰는가
+
+`parse_sql`은 호출자 `out`에 바로 쓰지 않고, 로컬 `Statement stmt`를 먼저 구성한다.
+
+이 방식의 장점은 다음과 같다.
+
+- 중간에 실패해도 로컬 객체만 안전하게 정리하면 된다.
+- 호출자는 반쯤 채워진 객체를 받지 않는다.
+- 성공한 경우에만 `*out = stmt`로 소유권을 넘기면 된다.
+
+## 9. CLI 설계
+
+`main.c`는 Phase 1에서 일부러 단순하게 유지했다.
+
+흐름은 다음과 같다.
+
+1. 인자 검증
+2. SQL 파일 전체 읽기
+3. `parse_sql` 호출
+4. 성공 시 AST 요약 출력
+5. 실패 시 에러 코드, 위치, 메시지 출력
+
+의도적으로 `execute_statement`는 호출하지 않는다.
+
+## 10. 테스트 설계
+
+테스트는 외부 프레임워크 없이 단일 C 실행 파일로 만들었다.
+
+이유는 다음과 같다.
+
+- 의존성을 최소화할 수 있다.
+- 단순한 C 환경에서 컴파일이 쉽다.
+- 각 테스트가 파서 계약을 설명하는 문서 역할도 한다.
+
+### 추가한 성공 케이스
+
+- 단순 INSERT
+- 단순 SELECT
+- schema 포함 이름
+- 혼합 대소문자 키워드
+- 과한 공백과 개행
+- 음수 정수
+
+### 추가한 실패 케이스
+
+- 세미콜론 누락
+- SELECT 컬럼 목록 사용
+- 닫히지 않은 문자열
+- 다중 문장
+- WHERE 절 사용
+
+## 11. 구현 중 유지한 규칙
+
+- Phase 1은 파싱에만 집중한다.
+- 소유권을 항상 명시적으로 유지한다.
+- 에러 위치는 가능한 실제 실패 지점에 가깝게 기록한다.
+- MVP 문법 밖 기능을 조용히 확장하지 않는다.
+- 실행기/저장소 로직을 파서 단계에 섞지 않는다.
+
+## 12. Phase 1에서 의도적으로 뺀 기능
+
+- 문자열 escape 미지원
+- 부동소수점 미지원
+- `WHERE` 미지원
+- 컬럼 선택 미지원
+- 다중 문장 미지원
+- CSV 읽기/쓰기 실행 미지원
+- 아래 함수는 스텁만 유지
   - `execute_statement`
   - `storage_append_row`
 
-## 13. Review Questions to Confirm Understanding
-- Why is the manual scanner a better fit than `strtok` here?
-- Who owns `Statement` memory after `parse_sql` succeeds?
-- Why is a local temporary `Statement` safer than writing directly into `out` from the start?
-- Why is `err.position` valuable during debugging?
+## 13. 리뷰할 때 확인하면 좋은 질문
 
-## 14. Current Status
-- Phase 1 implementation is complete.
-- Phase 2 has not started.
-- `Agents.md` has been updated with current state.
-- Compile and runtime verification are still pending because the current shell lacks a usable compiler toolchain.
+- 왜 수동 스캐너가 `strtok`보다 이 문제에 잘 맞는가
+- `parse_sql` 성공 후 `Statement` 메모리 소유자는 누구인가
+- 처음부터 `out`에 직접 쓰지 않고 임시 `Statement`를 쓰는 이유는 무엇인가
+- `err.position`이 디버깅에 왜 중요한가
 
-## 15. Post-review Structure Refactor
-- The parser remains the teaching center of the project.
-- Public headers are now split by role:
-  - shared constants
-  - error handling
-  - AST types
+## 14. 현재 상태
+
+- Phase 1 구현은 완료되었다.
+- Phase 2는 아직 시작하지 않았다.
+- 현재 상태는 `Agents.md`에도 반영되어 있다.
+- 한동안은 현재 셸에 툴체인이 없어 컴파일 검증이 막혀 있었지만, 이후 Windows Dev-Cpp MinGW 기준 직접 빌드와 테스트를 수행했다.
+
+## 15. 리뷰 후 구조 리팩터링
+
+- 파서는 여전히 프로젝트의 학습 중심이다.
+- 공개 헤더는 역할별로 나누었다.
+  - 공통 상수
+  - 에러 처리
+  - AST 타입
   - parser API
   - executor API
   - storage API
-- `include/sql_processor.h` remains as a convenience umbrella include so entry-level readers still have a simple starting point.
-- `execute_statement` and `storage_append_row` now exist as explicit stub modules.
-- This keeps the Phase 1 code easy to learn while making the Phase 2 extension points visible in the actual build graph.
-- Some earlier line-by-line review references in this document describe the pre-refactor layout and should be refreshed after the next compile-capable review pass.
-
-## 15. Code Review Focus Map
-
-### 15-1. Public contract and type boundaries
-- Check `include/sql_processor.h:11-66`.
-- Review points:
-  - whether `SqlError` carries enough information for parser and executor stages,
-  - whether `Statement` is minimal but sufficient for MVP,
-  - whether `SqlValue` is the right tagged-union shape for later CSV serialization,
-  - whether helper APIs like `statement_init` and `statement_free` are correctly exposed.
-
-### 15-2. AST initialization and cleanup discipline
-- Check `src/statement.c:6-32`.
-- Review points:
-  - whether every heap-owned field is released,
-  - whether cleanup is safe when only part of the AST was initialized,
-  - whether `statement_init` after free prevents stale pointers and double-free risk.
-
-### 15-3. Error reporting pattern
-- Check `src/parser.c:16-39`.
-- Review points:
-  - whether `clear_error` and `set_error` are called consistently,
-  - whether the `position` recorded is close enough to the real fault,
-  - whether error codes distinguish lexical, parse, unsupported, and memory failures clearly enough.
-
-### 15-4. Scanner movement and keyword matching
-- Check `src/parser.c:57-123`.
-- Review points:
-  - whether `current_char` handles end-of-buffer safely,
-  - whether `skip_whitespace` is applied at the right times,
-  - whether `match_keyword` correctly rejects prefixes such as `SELECTED`,
-  - whether case-insensitive matching is limited to ASCII in an intentional way.
-
-### 15-5. Identifier parsing and qualified name parsing
-- Check `src/parser.c:126-180`.
-- Review points:
-  - whether identifier syntax matches the intended grammar,
-  - whether `schema.table` and plain `table` are both handled cleanly,
-  - whether memory allocated for the first identifier is freed correctly if parsing the second identifier fails.
-
-### 15-6. Integer and string literal parsing
-- Check `src/parser.c:194-267`.
-- Review points:
-  - whether signed integers are accepted correctly,
-  - whether `strtoll` failure and range overflow are handled,
-  - whether unterminated strings are reported at the right location,
-  - whether the current no-escape-string rule is explicit enough for MVP.
-
-### 15-7. Dynamic array growth and VALUES list ownership
-- Check `src/parser.c:269-357`.
-- Review points:
-  - whether a string value is freed if `realloc` fails,
-  - whether `append_value` copies the union payload safely,
-  - whether empty `VALUES ()` is rejected intentionally,
-  - whether comma and closing parenthesis handling is strict enough.
-
-### 15-8. Statement-level parse flow and cleanup on failure
-- Check `src/parser.c:360-456`.
-- Review points:
-  - whether `INSERT` and `SELECT` paths are separated cleanly,
-  - whether unsupported syntax fails early and explicitly,
-  - whether the final semicolon and trailing-content checks correctly enforce one statement per file,
-  - whether `statement_free(&stmt)` is called on every failure path after allocation may have happened,
-  - whether ownership moves to `out` only on success.
-
-### 15-9. CLI file read path and resource lifetime
-- Check `src/main.c:15-63` and `src/main.c:98-133`.
-- Review points:
-  - whether file size discovery and full-buffer read are handled safely,
-  - whether the SQL text buffer is always freed on parser failure,
-  - whether `statement_free` is called on success,
-  - whether Phase 1 intentionally stops after parse summary and does not leak into executor work.
-
-### 15-10. Test coverage quality
-- Check `tests/test_parser.c:15-161`.
-- Review points:
-  - whether the tests reflect the MVP grammar exactly,
-  - whether both success and failure paths are covered,
-  - whether unsupported syntax tests are strong enough,
-  - whether any important edge case is still missing.
-
-## 16. Explanation-to-Code Index
-
-### "Why not `strtok`?"
-- Primary code:
-  - `src/parser.c:57-123`
-  - `src/parser.c:396-456`
-- Explain:
-  - parser state is tracked with `pos`,
-  - input is not mutated,
-  - exact failure position is preserved,
-  - grammar tokens are consumed under parser control.
-
-### "How does the parser walk through the SQL string?"
-- Primary code:
-  - `src/parser.c:65-69`
-  - `src/parser.c:112-123`
-  - `src/parser.c:312-357`
-  - `src/parser.c:396-456`
-- Explain:
-  - skip whitespace,
-  - expect or match the next grammar element,
-  - advance `pos`,
-  - stop on the first invalid token and record the fault.
-
-### "How is heap ownership managed?"
-- Primary code:
-  - `include/sql_processor.h:32-52`
-  - `src/parser.c:72-85`
-  - `src/parser.c:280-292`
-  - `src/parser.c:396-456`
-  - `src/statement.c:14-32`
-- Explain:
-  - copied identifiers and strings live on the heap,
-  - values array grows with `realloc`,
-  - successful parse transfers ownership to caller,
-  - `statement_free` is the single cleanup gate.
-
-### "Why use `out` and `err` pointers?"
-- Primary code:
-  - `include/sql_processor.h:48-66`
-  - `src/parser.c:16-39`
-  - `src/parser.c:396-456`
-  - `src/main.c:119-127`
-- Explain:
-  - return value controls success vs failure,
-  - `out` carries the AST only on success,
-  - `err` carries structured failure detail,
-  - caller logic stays linear and explicit.
-
-### "Where is the one-statement-only rule enforced?"
-- Primary code:
-  - `src/parser.c:440-452`
-- Explain:
-  - parser requires `;`,
-  - then skips trailing whitespace,
-  - then rejects any remaining non-whitespace input.
-
-### "Where are unsupported grammar decisions encoded?"
-- Primary code:
-  - `src/parser.c:324-327`
-  - `src/parser.c:383-385`
-  - `src/parser.c:435-437`
-  - `src/parser.c:449-451`
-  - `tests/test_parser.c:79-123`
-- Explain:
-  - empty `VALUES` is rejected,
-  - only `SELECT *` is allowed,
-  - only `INSERT` and `SELECT` statements are accepted,
-  - multiple statements are rejected,
-  - tests lock these choices in.
-
-### "Where should Phase 1 review stop and Phase 2 begin?"
-- Primary code:
-  - `src/main.c:87-96`
-  - `src/main.c:119-129`
-  - `include/sql_processor.h:59-66`
-- Explain:
-  - `execute_statement` and `storage_append_row` exist only as contracts,
-  - Phase 1 CLI stops after parse summary,
-  - no CSV execution logic is present yet.
+- `include/sql_processor.h`는 여전히 편의용 우산 헤더로 남겨 두었다.
+- `execute_statement`, `storage_append_row`는 명시적인 스텁 모듈로 분리했다.
+- 덕분에 Phase 1 코드는 읽기 쉽게 유지하면서도, Phase 2 확장 지점은 빌드 구조에 드러나게 되었다.
+- 이 문서의 일부 라인 번호 기반 리뷰 메모는 리팩터링 이전 기준일 수 있으므로, 다음 정리 때 최신 파일 위치에 맞춰 갱신하는 것이 좋다.

--- a/PHASE1_IMPLEMENTATION_NOTES.md
+++ b/PHASE1_IMPLEMENTATION_NOTES.md
@@ -1,0 +1,396 @@
+# Phase 1 Implementation Notes
+
+## Purpose
+- This document does not expose a raw internal thought log.
+- It records the shareable engineering rationale, implementation order, and review points for Phase 1.
+- Scope is limited to CLI setup and SQL parsing. Executor and storage are intentionally excluded.
+
+## Phase 1 Goal
+- Read one SQL file.
+- Accept exactly one SQL statement per file.
+- Support:
+  - `INSERT INTO [schema.]table VALUES (...);`
+  - `SELECT * FROM [schema.]table;`
+- Convert the SQL text into a `Statement` AST.
+- Stop at parsing in Phase 1. Do not execute storage logic yet.
+
+## 1. Initial Grounding
+- Confirmed the repository was nearly empty.
+- Created `Agents.md` first and used it as persistent project memory.
+- From that point on, the working rule became:
+  - read `Agents.md` before major work,
+  - update it after design decisions or task completion.
+
+## 2. Environment Facts Found First
+- The current PowerShell environment does not have `gcc`, `clang`, or `make` on PATH.
+- `cmake` exists, but the project contract is still `Makefile`.
+- `bash.exe` and `wsl.exe` are blocked by permission errors in this shell.
+- Result:
+  - code was written to portable C11 assumptions,
+  - runtime compile verification could not be completed from this shell,
+  - this status was recorded in `Agents.md`.
+
+## 3. Why the Implementation Started with Headers
+- The user already fixed the public interfaces.
+- Because of that, the safest order was:
+  1. define shared types and function declarations,
+  2. define ownership and cleanup rules,
+  3. build the parser on top of those rules,
+  4. build the CLI around the parser,
+  5. add tests around the parser contract.
+
+## 4. Shared Type Design
+
+### `SqlError`
+- C has no exception system.
+- A plain integer return value is not enough for useful debugging.
+- `SqlError` stores:
+  - `code`
+  - `position`
+  - `message`
+- This makes parser failures observable and reviewable.
+
+### `Statement`
+- MVP only needs two statement kinds:
+  - `STMT_INSERT`
+  - `STMT_SELECT`
+- Common fields:
+  - `type`
+  - `schema`
+  - `table`
+- Insert-specific payload:
+  - `values`
+  - `value_count`
+- `SELECT *` needs no column list in Phase 1.
+
+### `SqlValue`
+- Values are either integers or strings.
+- A tagged union was chosen:
+  - `type` tells which variant is active,
+  - the union stores the actual payload.
+- This keeps the representation compact and reusable for Phase 2 CSV output.
+
+## 5. Memory Ownership Strategy
+- The first critical C design question was ownership.
+- The chosen rule is heap-owned AST data:
+  - parser deep-copies identifiers and string literals,
+  - parser allocates the `values` array,
+  - caller owns the successful `Statement`,
+  - caller must release it with `statement_free`.
+
+### Why this strategy
+- AST lifetime is decoupled from the input SQL buffer lifetime.
+- The CLI can free the original file buffer without invalidating the AST.
+- Tests stay simple because they do not depend on input string lifetime.
+
+### Success and failure behavior
+- On success:
+  - `out` receives ownership of all heap data.
+- On failure:
+  - the parser frees all partially built allocations before returning.
+- This keeps the caller from dealing with partially initialized cleanup.
+
+## 6. Why a Manual Scanner Was Chosen Instead of `strtok`
+- SQL parsing needs context-sensitive control over:
+  - whitespace,
+  - punctuation,
+  - keywords,
+  - quoted strings,
+  - exact error position.
+- `strtok` was rejected because it:
+  - mutates the input buffer,
+  - makes position tracking harder,
+  - handles quoted strings poorly,
+  - is awkward for tokens like `.`, `(`, `)`, `,`, `;`.
+- A manual scanner was used instead:
+  - `Parser { input, length, pos }`
+  - helper functions inspect and advance one region at a time.
+
+## 7. Parser Construction Order
+
+### 7-1. Minimal scanner helpers
+- `current_char`
+- `skip_whitespace`
+- `copy_substring`
+- `match_keyword`
+- `expect_keyword`
+
+These functions define the basic "read at current position, then advance" model.
+
+### 7-2. Identifier parsing
+- `parse_identifier` accepts `[A-Za-z_]` followed by `[A-Za-z0-9_]*`.
+- `parse_qualified_name` reads either:
+  - `table`
+  - `schema.table`
+
+### 7-3. Literal parsing
+- Integer literals use `strtoll`.
+- String literals copy the content between single quotes.
+- Quote escaping is intentionally not supported in MVP.
+
+### 7-4. VALUES list parsing
+- Confirm `(`.
+- Parse one value.
+- Repeatedly accept either:
+  - `,` and another value,
+  - `)` to finish.
+- Empty `()` is rejected in MVP.
+
+### 7-5. Statement parsing
+- `INSERT` path:
+  - `INTO`
+  - target table
+  - `VALUES`
+  - values list
+- `SELECT` path:
+  - `*`
+  - `FROM`
+  - target table
+
+### 7-6. Statement termination
+- Require a final `;`.
+- Allow only trailing whitespace after `;`.
+- This enforces the "one statement per file" rule.
+
+## 8. Why `parse_sql` Uses a Temporary Local `Statement`
+- `parse_sql` builds a local `Statement stmt` first.
+- If parsing fails halfway, that local object can be cleaned safely.
+- Only on success does the function transfer it with `*out = stmt`.
+- This avoids leaving the caller with a half-built object.
+
+## 9. CLI Construction
+- `main.c` was intentionally kept small in Phase 1.
+- Execution order:
+  1. validate CLI arguments,
+  2. read the SQL file into memory,
+  3. call `parse_sql`,
+  4. print a normalized AST summary on success,
+  5. print code, position, and message on failure.
+- `execute_statement` is not called yet by design.
+
+## 10. Test Construction
+- Tests were written as a single C executable without external frameworks.
+- Reasons:
+  - minimal dependency surface,
+  - easy to compile in a basic C environment,
+  - each test also documents one parser behavior.
+
+### Success cases added
+- simple insert
+- simple select
+- qualified schema name
+- mixed case keywords
+- extra whitespace and newlines
+- negative integer
+
+### Failure cases added
+- missing semicolon
+- column list in select
+- unterminated string
+- multiple statements
+- where clause usage
+
+## 11. Ongoing Design Rules During Implementation
+- Keep Phase 1 focused on parsing only.
+- Keep ownership explicit.
+- Record error positions as close to the actual fault as possible.
+- Do not silently expand beyond the MVP grammar.
+- Do not mix executor or storage behavior into the parser phase.
+
+## 12. Intentional Non-Features in Phase 1
+- no string escape support
+- no floating point numbers
+- no `WHERE`
+- no column selection
+- no multiple statements
+- no CSV read/write execution
+- no implementation yet for:
+  - `execute_statement`
+  - `storage_append_row`
+
+## 13. Review Questions to Confirm Understanding
+- Why is the manual scanner a better fit than `strtok` here?
+- Who owns `Statement` memory after `parse_sql` succeeds?
+- Why is a local temporary `Statement` safer than writing directly into `out` from the start?
+- Why is `err.position` valuable during debugging?
+
+## 14. Current Status
+- Phase 1 implementation is complete.
+- Phase 2 has not started.
+- `Agents.md` has been updated with current state.
+- Compile and runtime verification are still pending because the current shell lacks a usable compiler toolchain.
+
+## 15. Post-review Structure Refactor
+- The parser remains the teaching center of the project.
+- Public headers are now split by role:
+  - shared constants
+  - error handling
+  - AST types
+  - parser API
+  - executor API
+  - storage API
+- `include/sql_processor.h` remains as a convenience umbrella include so entry-level readers still have a simple starting point.
+- `execute_statement` and `storage_append_row` now exist as explicit stub modules.
+- This keeps the Phase 1 code easy to learn while making the Phase 2 extension points visible in the actual build graph.
+- Some earlier line-by-line review references in this document describe the pre-refactor layout and should be refreshed after the next compile-capable review pass.
+
+## 15. Code Review Focus Map
+
+### 15-1. Public contract and type boundaries
+- Check `include/sql_processor.h:11-66`.
+- Review points:
+  - whether `SqlError` carries enough information for parser and executor stages,
+  - whether `Statement` is minimal but sufficient for MVP,
+  - whether `SqlValue` is the right tagged-union shape for later CSV serialization,
+  - whether helper APIs like `statement_init` and `statement_free` are correctly exposed.
+
+### 15-2. AST initialization and cleanup discipline
+- Check `src/statement.c:6-32`.
+- Review points:
+  - whether every heap-owned field is released,
+  - whether cleanup is safe when only part of the AST was initialized,
+  - whether `statement_init` after free prevents stale pointers and double-free risk.
+
+### 15-3. Error reporting pattern
+- Check `src/parser.c:16-39`.
+- Review points:
+  - whether `clear_error` and `set_error` are called consistently,
+  - whether the `position` recorded is close enough to the real fault,
+  - whether error codes distinguish lexical, parse, unsupported, and memory failures clearly enough.
+
+### 15-4. Scanner movement and keyword matching
+- Check `src/parser.c:57-123`.
+- Review points:
+  - whether `current_char` handles end-of-buffer safely,
+  - whether `skip_whitespace` is applied at the right times,
+  - whether `match_keyword` correctly rejects prefixes such as `SELECTED`,
+  - whether case-insensitive matching is limited to ASCII in an intentional way.
+
+### 15-5. Identifier parsing and qualified name parsing
+- Check `src/parser.c:126-180`.
+- Review points:
+  - whether identifier syntax matches the intended grammar,
+  - whether `schema.table` and plain `table` are both handled cleanly,
+  - whether memory allocated for the first identifier is freed correctly if parsing the second identifier fails.
+
+### 15-6. Integer and string literal parsing
+- Check `src/parser.c:194-267`.
+- Review points:
+  - whether signed integers are accepted correctly,
+  - whether `strtoll` failure and range overflow are handled,
+  - whether unterminated strings are reported at the right location,
+  - whether the current no-escape-string rule is explicit enough for MVP.
+
+### 15-7. Dynamic array growth and VALUES list ownership
+- Check `src/parser.c:269-357`.
+- Review points:
+  - whether a string value is freed if `realloc` fails,
+  - whether `append_value` copies the union payload safely,
+  - whether empty `VALUES ()` is rejected intentionally,
+  - whether comma and closing parenthesis handling is strict enough.
+
+### 15-8. Statement-level parse flow and cleanup on failure
+- Check `src/parser.c:360-456`.
+- Review points:
+  - whether `INSERT` and `SELECT` paths are separated cleanly,
+  - whether unsupported syntax fails early and explicitly,
+  - whether the final semicolon and trailing-content checks correctly enforce one statement per file,
+  - whether `statement_free(&stmt)` is called on every failure path after allocation may have happened,
+  - whether ownership moves to `out` only on success.
+
+### 15-9. CLI file read path and resource lifetime
+- Check `src/main.c:15-63` and `src/main.c:98-133`.
+- Review points:
+  - whether file size discovery and full-buffer read are handled safely,
+  - whether the SQL text buffer is always freed on parser failure,
+  - whether `statement_free` is called on success,
+  - whether Phase 1 intentionally stops after parse summary and does not leak into executor work.
+
+### 15-10. Test coverage quality
+- Check `tests/test_parser.c:15-161`.
+- Review points:
+  - whether the tests reflect the MVP grammar exactly,
+  - whether both success and failure paths are covered,
+  - whether unsupported syntax tests are strong enough,
+  - whether any important edge case is still missing.
+
+## 16. Explanation-to-Code Index
+
+### "Why not `strtok`?"
+- Primary code:
+  - `src/parser.c:57-123`
+  - `src/parser.c:396-456`
+- Explain:
+  - parser state is tracked with `pos`,
+  - input is not mutated,
+  - exact failure position is preserved,
+  - grammar tokens are consumed under parser control.
+
+### "How does the parser walk through the SQL string?"
+- Primary code:
+  - `src/parser.c:65-69`
+  - `src/parser.c:112-123`
+  - `src/parser.c:312-357`
+  - `src/parser.c:396-456`
+- Explain:
+  - skip whitespace,
+  - expect or match the next grammar element,
+  - advance `pos`,
+  - stop on the first invalid token and record the fault.
+
+### "How is heap ownership managed?"
+- Primary code:
+  - `include/sql_processor.h:32-52`
+  - `src/parser.c:72-85`
+  - `src/parser.c:280-292`
+  - `src/parser.c:396-456`
+  - `src/statement.c:14-32`
+- Explain:
+  - copied identifiers and strings live on the heap,
+  - values array grows with `realloc`,
+  - successful parse transfers ownership to caller,
+  - `statement_free` is the single cleanup gate.
+
+### "Why use `out` and `err` pointers?"
+- Primary code:
+  - `include/sql_processor.h:48-66`
+  - `src/parser.c:16-39`
+  - `src/parser.c:396-456`
+  - `src/main.c:119-127`
+- Explain:
+  - return value controls success vs failure,
+  - `out` carries the AST only on success,
+  - `err` carries structured failure detail,
+  - caller logic stays linear and explicit.
+
+### "Where is the one-statement-only rule enforced?"
+- Primary code:
+  - `src/parser.c:440-452`
+- Explain:
+  - parser requires `;`,
+  - then skips trailing whitespace,
+  - then rejects any remaining non-whitespace input.
+
+### "Where are unsupported grammar decisions encoded?"
+- Primary code:
+  - `src/parser.c:324-327`
+  - `src/parser.c:383-385`
+  - `src/parser.c:435-437`
+  - `src/parser.c:449-451`
+  - `tests/test_parser.c:79-123`
+- Explain:
+  - empty `VALUES` is rejected,
+  - only `SELECT *` is allowed,
+  - only `INSERT` and `SELECT` statements are accepted,
+  - multiple statements are rejected,
+  - tests lock these choices in.
+
+### "Where should Phase 1 review stop and Phase 2 begin?"
+- Primary code:
+  - `src/main.c:87-96`
+  - `src/main.c:119-129`
+  - `include/sql_processor.h:59-66`
+- Explain:
+  - `execute_statement` and `storage_append_row` exist only as contracts,
+  - Phase 1 CLI stops after parse summary,
+  - no CSV execution logic is present yet.

--- a/README.md
+++ b/README.md
@@ -30,3 +30,12 @@ Mini SQL processor draft for Week 6.
 - The parser stays small and easy to trace for learning.
 - Executor and storage are split early so Phase 2 work stays isolated.
 - `sql_processor.h` remains as a simple entry point, while module headers make responsibilities explicit.
+
+## CI/CD
+
+- CI: GitHub Actions runs on push and pull request.
+  - Ubuntu: `gcc`, `clang`
+  - Windows: MinGW via MSYS2
+  - Each job builds the project, runs parser tests, and executes the sample `INSERT` / `SELECT` queries.
+- CD: pushing a tag like `v0.1.0` builds Linux and Windows release bundles and publishes them as GitHub Release assets.
+- Manual release-asset verification is also available through `workflow_dispatch` on the `Release` workflow.

--- a/README.md
+++ b/README.md
@@ -1,41 +1,71 @@
 # SQL_WednsdayCodingClub
 
-Mini SQL processor draft for Week 6.
+Week 6 학습용 미니 SQL Processor 초안입니다.
 
-## Current Scope
+## 현재 범위
 
-- Parse exactly one SQL statement from a file
-- Support `INSERT INTO [schema.]table VALUES (...);`
-- Support `SELECT * FROM [schema.]table;`
-- Stop at parsing in Phase 1
+- SQL 파일 하나에서 문장 하나만 읽습니다.
+- 아래 두 문법만 지원합니다.
+  - `INSERT INTO [schema.]table VALUES (...);`
+  - `SELECT * FROM [schema.]table;`
+- Phase 1에서는 파싱까지만 수행합니다.
+- 실행기와 저장소 로직은 Phase 2용 스텁으로만 분리되어 있습니다.
 
-## Project Layout
+## 프로젝트 구조
 
-- `include/sql_processor.h`: umbrella header for the whole project
-- `include/sql_common.h`: shared constants
-- `include/sql_error.h`: error model and helpers
-- `include/sql_types.h`: AST types and cleanup helpers
-- `include/parse.h`: parser API
-- `include/execute.h`: Phase 2 executor API
-- `include/storage.h`: Phase 2 storage API
-- `src/parser.c`: manual SQL scanner and parser
-- `src/statement.c`: AST lifecycle helpers
-- `src/sql_error.c`: shared error formatting helpers
-- `src/execute_stub.c`: explicit Phase 2 placeholder
-- `src/storage_stub.c`: explicit Phase 2 placeholder
-- `tests/test_parser.c`: parser-focused unit tests
+- `include/sql_processor.h`
+  - 전체 프로젝트를 한 번에 포함하는 우산 헤더입니다.
+- `include/sql_common.h`
+  - 공통 상수와 성공/실패 코드를 정의합니다.
+- `include/sql_error.h`
+  - 에러 코드, 에러 구조체, 에러 설정 함수를 정의합니다.
+- `include/sql_types.h`
+  - AST 역할을 하는 `Statement`, `SqlValue` 타입과 정리 함수를 정의합니다.
+- `include/parse.h`
+  - 파서 공개 API를 정의합니다.
+- `include/execute.h`
+  - Phase 2 실행기 공개 API를 정의합니다.
+- `include/storage.h`
+  - Phase 2 저장소 공개 API를 정의합니다.
+- `src/parser.c`
+  - 수동 스캐너 기반 SQL 파서를 구현합니다.
+- `src/statement.c`
+  - AST 초기화와 해제를 담당합니다.
+- `src/sql_error.c`
+  - 공통 에러 처리 함수를 구현합니다.
+- `src/main.c`
+  - CLI 진입점입니다. 파일을 읽고 파서를 호출하고 결과를 출력합니다.
+- `src/execute_stub.c`
+  - Phase 2 실행기 자리만 잡아둔 스텁입니다.
+- `src/storage_stub.c`
+  - Phase 2 저장소 자리만 잡아둔 스텁입니다.
+- `tests/test_parser.c`
+  - 파서 단위 테스트를 담고 있습니다.
 
-## Why This Shape
+## 왜 이렇게 나눴는가
 
-- The parser stays small and easy to trace for learning.
-- Executor and storage are split early so Phase 2 work stays isolated.
-- `sql_processor.h` remains as a simple entry point, while module headers make responsibilities explicit.
+- 파서를 학습 중심으로 읽기 쉽게 유지하기 위해서입니다.
+- 실행기와 저장소는 아직 구현하지 않지만, 나중에 붙일 경계는 미리 분리해 두기 위해서입니다.
+- `sql_processor.h`는 진입점을 단순하게 유지하고, 실제 책임은 개별 헤더가 나누어 갖도록 하기 위해서입니다.
+
+## 빌드와 테스트
+
+기본 빌드는 `Makefile` 기준입니다.
+
+```bash
+make clean all
+make test
+```
+
+현재 Windows 로컬 환경에서는 경로 이슈 때문에 `mingw32-make`가 실패할 수 있어 direct `gcc` 빌드로 검증했습니다.
 
 ## CI/CD
 
-- CI: GitHub Actions runs on push and pull request.
-  - Ubuntu: `gcc`, `clang`
-  - Windows: MinGW via MSYS2
-  - Each job builds the project, runs parser tests, and executes the sample `INSERT` / `SELECT` queries.
-- CD: pushing a tag like `v0.1.0` builds Linux and Windows release bundles and publishes them as GitHub Release assets.
-- Manual release-asset verification is also available through `workflow_dispatch` on the `Release` workflow.
+- CI
+  - GitHub Actions가 `push`와 `pull_request`에서 자동 실행됩니다.
+  - Ubuntu에서는 `gcc`, `clang`으로 빌드와 테스트를 수행합니다.
+  - Windows에서는 MSYS2 MinGW로 빌드와 테스트를 수행합니다.
+  - 각 잡은 바이너리 빌드, parser 테스트, sample `INSERT` / `SELECT` 쿼리 실행까지 확인합니다.
+- CD
+  - `v0.1.0` 같은 태그를 푸시하면 Linux/Windows 릴리스 번들을 만들고 GitHub Release 자산으로 업로드합니다.
+  - `workflow_dispatch`로 수동 릴리스 빌드도 가능합니다.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # SQL_WednsdayCodingClub
-WEEK6
+
+Mini SQL processor draft for Week 6.
+
+## Current Scope
+
+- Parse exactly one SQL statement from a file
+- Support `INSERT INTO [schema.]table VALUES (...);`
+- Support `SELECT * FROM [schema.]table;`
+- Stop at parsing in Phase 1
+
+## Project Layout
+
+- `include/sql_processor.h`: umbrella header for the whole project
+- `include/sql_common.h`: shared constants
+- `include/sql_error.h`: error model and helpers
+- `include/sql_types.h`: AST types and cleanup helpers
+- `include/parse.h`: parser API
+- `include/execute.h`: Phase 2 executor API
+- `include/storage.h`: Phase 2 storage API
+- `src/parser.c`: manual SQL scanner and parser
+- `src/statement.c`: AST lifecycle helpers
+- `src/sql_error.c`: shared error formatting helpers
+- `src/execute_stub.c`: explicit Phase 2 placeholder
+- `src/storage_stub.c`: explicit Phase 2 placeholder
+- `tests/test_parser.c`: parser-focused unit tests
+
+## Why This Shape
+
+- The parser stays small and easy to trace for learning.
+- Executor and storage are split early so Phase 2 work stays isolated.
+- `sql_processor.h` remains as a simple entry point, while module headers make responsibilities explicit.

--- a/data/users.csv
+++ b/data/users.csv
@@ -1,0 +1,2 @@
+id,name,age
+1,alice,20

--- a/include/execute.h
+++ b/include/execute.h
@@ -7,6 +7,7 @@
 #include "sql_error.h"
 #include "sql_types.h"
 
+/* Phase 2에서 AST를 실제 동작으로 연결하는 실행기 진입점이다. */
 int execute_statement(const Statement *stmt, const char *data_dir, FILE *out, SqlError *err);
 
 #endif

--- a/include/execute.h
+++ b/include/execute.h
@@ -1,0 +1,12 @@
+#ifndef EXECUTE_H
+#define EXECUTE_H
+
+#include <stdio.h>
+
+#include "sql_common.h"
+#include "sql_error.h"
+#include "sql_types.h"
+
+int execute_statement(const Statement *stmt, const char *data_dir, FILE *out, SqlError *err);
+
+#endif

--- a/include/parse.h
+++ b/include/parse.h
@@ -5,6 +5,7 @@
 #include "sql_error.h"
 #include "sql_types.h"
 
+/* 성공하면 out이 완성된 AST를 소유하고, 실패하면 err에 원인을 기록한다. */
 int parse_sql(const char *sql, Statement *out, SqlError *err);
 
 #endif

--- a/include/parse.h
+++ b/include/parse.h
@@ -1,0 +1,10 @@
+#ifndef PARSE_H
+#define PARSE_H
+
+#include "sql_common.h"
+#include "sql_error.h"
+#include "sql_types.h"
+
+int parse_sql(const char *sql, Statement *out, SqlError *err);
+
+#endif

--- a/include/sql_common.h
+++ b/include/sql_common.h
@@ -1,0 +1,8 @@
+#ifndef SQL_COMMON_H
+#define SQL_COMMON_H
+
+#define SQL_SUCCESS 0
+#define SQL_FAILURE 1
+#define SQL_DEFAULT_DATA_DIR "data"
+
+#endif

--- a/include/sql_error.h
+++ b/include/sql_error.h
@@ -1,0 +1,27 @@
+#ifndef SQL_ERROR_H
+#define SQL_ERROR_H
+
+#include <stddef.h>
+
+typedef enum SqlErrorCode {
+    SQL_ERR_NONE = 0,
+    SQL_ERR_ARGUMENT,
+    SQL_ERR_IO,
+    SQL_ERR_LEX,
+    SQL_ERR_PARSE,
+    SQL_ERR_UNSUPPORTED,
+    SQL_ERR_MEMORY,
+    SQL_ERR_NOT_IMPLEMENTED
+} SqlErrorCode;
+
+typedef struct SqlError {
+    SqlErrorCode code;
+    size_t position;
+    char message[256];
+} SqlError;
+
+void sql_error_clear(SqlError *err);
+void sql_error_set(SqlError *err, SqlErrorCode code, size_t position, const char *fmt, ...);
+const char *sql_error_code_name(SqlErrorCode code);
+
+#endif

--- a/include/sql_error.h
+++ b/include/sql_error.h
@@ -14,12 +14,14 @@ typedef enum SqlErrorCode {
     SQL_ERR_NOT_IMPLEMENTED
 } SqlErrorCode;
 
+/* 실패 원인을 코드, 위치, 메시지로 함께 전달한다. */
 typedef struct SqlError {
     SqlErrorCode code;
     size_t position;
     char message[256];
 } SqlError;
 
+/* 에러 구조체를 재사용하기 쉽게 초기화한다. */
 void sql_error_clear(SqlError *err);
 void sql_error_set(SqlError *err, SqlErrorCode code, size_t position, const char *fmt, ...);
 const char *sql_error_code_name(SqlErrorCode code);

--- a/include/sql_processor.h
+++ b/include/sql_processor.h
@@ -1,0 +1,11 @@
+#ifndef SQL_PROCESSOR_H
+#define SQL_PROCESSOR_H
+
+#include "sql_common.h"
+#include "sql_error.h"
+#include "sql_types.h"
+#include "parse.h"
+#include "execute.h"
+#include "storage.h"
+
+#endif

--- a/include/sql_types.h
+++ b/include/sql_types.h
@@ -14,6 +14,7 @@ typedef enum SqlValueType {
     SQL_VALUE_STRING
 } SqlValueType;
 
+/* SQL 리터럴 한 개를 표현한다. */
 typedef struct SqlValue {
     SqlValueType type;
     union {
@@ -22,6 +23,7 @@ typedef struct SqlValue {
     } as;
 } SqlValue;
 
+/* parser가 만들어 내는 최소 AST 구조다. */
 typedef struct Statement {
     StatementType type;
     char *schema;
@@ -30,6 +32,7 @@ typedef struct Statement {
     size_t value_count;
 } Statement;
 
+/* 성공 시 Statement 내부 문자열/배열 소유권은 호출자에게 넘어간다. */
 void statement_init(Statement *stmt);
 void statement_free(Statement *stmt);
 const char *statement_type_name(StatementType type);

--- a/include/sql_types.h
+++ b/include/sql_types.h
@@ -1,0 +1,37 @@
+#ifndef SQL_TYPES_H
+#define SQL_TYPES_H
+
+#include <stddef.h>
+
+typedef enum StatementType {
+    STMT_NONE = 0,
+    STMT_INSERT,
+    STMT_SELECT
+} StatementType;
+
+typedef enum SqlValueType {
+    SQL_VALUE_INT = 0,
+    SQL_VALUE_STRING
+} SqlValueType;
+
+typedef struct SqlValue {
+    SqlValueType type;
+    union {
+        long long int_value;
+        char *string_value;
+    } as;
+} SqlValue;
+
+typedef struct Statement {
+    StatementType type;
+    char *schema;
+    char *table;
+    SqlValue *values;
+    size_t value_count;
+} Statement;
+
+void statement_init(Statement *stmt);
+void statement_free(Statement *stmt);
+const char *statement_type_name(StatementType type);
+
+#endif

--- a/include/storage.h
+++ b/include/storage.h
@@ -7,6 +7,7 @@
 #include "sql_error.h"
 #include "sql_types.h"
 
+/* Phase 2에서 VALUES를 CSV 행으로 저장하는 저장소 경계다. */
 int storage_append_row(const char *data_dir,
                        const char *schema,
                        const char *table,

--- a/include/storage.h
+++ b/include/storage.h
@@ -1,0 +1,17 @@
+#ifndef STORAGE_H
+#define STORAGE_H
+
+#include <stddef.h>
+
+#include "sql_common.h"
+#include "sql_error.h"
+#include "sql_types.h"
+
+int storage_append_row(const char *data_dir,
+                       const char *schema,
+                       const char *table,
+                       const SqlValue *values,
+                       size_t value_count,
+                       SqlError *err);
+
+#endif

--- a/queries/insert_users.sql
+++ b/queries/insert_users.sql
@@ -1,0 +1,1 @@
+INSERT INTO users VALUES (1, 'alice', 20);

--- a/queries/select_users.sql
+++ b/queries/select_users.sql
@@ -1,0 +1,1 @@
+SELECT * FROM users;

--- a/src/execute_stub.c
+++ b/src/execute_stub.c
@@ -1,0 +1,17 @@
+#include "execute.h"
+
+int execute_statement(const Statement *stmt, const char *data_dir, FILE *out, SqlError *err) {
+    (void) stmt;
+    (void) data_dir;
+    (void) out;
+
+    if (err == NULL) {
+        return SQL_FAILURE;
+    }
+
+    sql_error_set(err,
+                  SQL_ERR_NOT_IMPLEMENTED,
+                  0,
+                  "execute_statement is reserved for Phase 2");
+    return SQL_FAILURE;
+}

--- a/src/execute_stub.c
+++ b/src/execute_stub.c
@@ -1,5 +1,6 @@
 #include "execute.h"
 
+/* Phase 2 전까지는 링크 구조만 유지하고 실제 실행은 막는다. */
 int execute_statement(const Statement *stmt, const char *data_dir, FILE *out, SqlError *err) {
     (void) stmt;
     (void) data_dir;

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,140 @@
+#include "parse.h"
+#include "sql_error.h"
+#include "sql_types.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef _WIN32
+#define SIZE_T_FMT "%Iu"
+#define LONG_LONG_FMT "%I64d"
+#else
+#define SIZE_T_FMT "%zu"
+#define LONG_LONG_FMT "%lld"
+#endif
+
+static char *read_entire_file(const char *path, SqlError *err) {
+    FILE *file;
+    long size;
+    size_t read_size;
+    char *buffer;
+
+    file = fopen(path, "rb");
+    if (file == NULL) {
+        sql_error_set(err, SQL_ERR_IO, 0, "Failed to open SQL file '%s'", path);
+        return NULL;
+    }
+
+    if (fseek(file, 0L, SEEK_END) != 0) {
+        fclose(file);
+        sql_error_set(err, SQL_ERR_IO, 0, "Failed to seek SQL file '%s'", path);
+        return NULL;
+    }
+
+    size = ftell(file);
+    if (size < 0) {
+        fclose(file);
+        sql_error_set(err, SQL_ERR_IO, 0, "Failed to determine SQL file size '%s'", path);
+        return NULL;
+    }
+
+    if (fseek(file, 0L, SEEK_SET) != 0) {
+        fclose(file);
+        sql_error_set(err, SQL_ERR_IO, 0, "Failed to rewind SQL file '%s'", path);
+        return NULL;
+    }
+
+    buffer = (char *) malloc((size_t) size + 1);
+    if (buffer == NULL) {
+        fclose(file);
+        sql_error_set(err, SQL_ERR_MEMORY, 0, "Out of memory while reading SQL file '%s'", path);
+        return NULL;
+    }
+
+    read_size = fread(buffer, 1u, (size_t) size, file);
+    if (read_size != (size_t) size) {
+        free(buffer);
+        fclose(file);
+        sql_error_set(err, SQL_ERR_IO, 0, "Failed to read entire SQL file '%s'", path);
+        return NULL;
+    }
+
+    buffer[read_size] = '\0';
+    fclose(file);
+    return buffer;
+}
+
+static void print_target(const Statement *stmt) {
+    if (stmt->schema != NULL) {
+        printf("Target: %s.%s\n", stmt->schema, stmt->table);
+    } else {
+        printf("Target: %s\n", stmt->table);
+    }
+}
+
+static void print_values(const Statement *stmt) {
+    size_t i;
+
+    printf("Values (" SIZE_T_FMT "):\n", stmt->value_count);
+    for (i = 0; i < stmt->value_count; ++i) {
+        if (stmt->values[i].type == SQL_VALUE_INT) {
+            printf("  [" SIZE_T_FMT "] INT " LONG_LONG_FMT "\n",
+                   i,
+                   stmt->values[i].as.int_value);
+        } else {
+            printf("  [" SIZE_T_FMT "] STRING '%s'\n",
+                   i,
+                   stmt->values[i].as.string_value);
+        }
+    }
+}
+
+static void print_statement_summary(const Statement *stmt, const char *data_dir) {
+    printf("Parse succeeded.\n");
+    printf("Statement: %s\n", statement_type_name(stmt->type));
+    printf("Data directory: %s\n", data_dir);
+    print_target(stmt);
+
+    if (stmt->type == STMT_INSERT) {
+        print_values(stmt);
+    }
+}
+
+int main(int argc, char **argv) {
+    const char *sql_path;
+    const char *data_dir;
+    char *sql_text;
+    Statement stmt;
+    SqlError err;
+
+    if (argc < 2 || argc > 3) {
+        fprintf(stderr, "Usage: %s <sql_file> [data_dir]\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    sql_path = argv[1];
+    data_dir = (argc == 3) ? argv[2] : SQL_DEFAULT_DATA_DIR;
+
+    sql_error_clear(&err);
+    sql_text = read_entire_file(sql_path, &err);
+    if (sql_text == NULL) {
+        fprintf(stderr, "I/O error: %s\n", err.message);
+        return EXIT_FAILURE;
+    }
+
+    statement_init(&stmt);
+    if (parse_sql(sql_text, &stmt, &err) != SQL_SUCCESS) {
+        fprintf(stderr, "Parse error [%s] at position " SIZE_T_FMT ": %s\n",
+                sql_error_code_name(err.code),
+                err.position,
+                err.message);
+        free(sql_text);
+        return EXIT_FAILURE;
+    }
+
+    print_statement_summary(&stmt, data_dir);
+
+    statement_free(&stmt);
+    free(sql_text);
+    return EXIT_SUCCESS;
+}

--- a/src/main.c
+++ b/src/main.c
@@ -13,6 +13,7 @@
 #define LONG_LONG_FMT "%lld"
 #endif
 
+/* SQL 파일 전체를 메모리에 올려 parser가 한 번에 읽을 수 있게 한다. */
 static char *read_entire_file(const char *path, SqlError *err) {
     FILE *file;
     long size;
@@ -64,6 +65,7 @@ static char *read_entire_file(const char *path, SqlError *err) {
     return buffer;
 }
 
+/* 사람이 읽을 수 있는 요약 형태로 AST를 출력한다. */
 static void print_target(const Statement *stmt) {
     if (stmt->schema != NULL) {
         printf("Target: %s.%s\n", stmt->schema, stmt->table);
@@ -132,6 +134,7 @@ int main(int argc, char **argv) {
         return EXIT_FAILURE;
     }
 
+    /* Phase 1은 파싱 결과 확인까지가 목적이므로 실행기로 넘기지 않는다. */
     print_statement_summary(&stmt, data_dir);
 
     statement_free(&stmt);

--- a/src/parser.c
+++ b/src/parser.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* 수동 스캐너의 현재 위치를 추적하는 상태 구조다. */
 typedef struct Parser {
     const char *input;
     size_t length;
@@ -57,6 +58,7 @@ static char *copy_substring(const char *start, size_t length) {
     return buffer;
 }
 
+/* 예약어 뒤에 식별자가 바로 붙는 경우를 막아 정확한 키워드만 소비한다. */
 static int match_keyword(Parser *parser, const char *keyword) {
     size_t start;
     size_t i;
@@ -204,6 +206,7 @@ static int parse_integer_value(Parser *parser, SqlValue *value, SqlError *err) {
     return SQL_SUCCESS;
 }
 
+/* MVP에서는 escape 없이 작은따옴표로 감싼 문자열만 허용한다. */
 static int parse_string_value(Parser *parser, SqlValue *value, SqlError *err) {
     size_t start;
     size_t length;
@@ -265,6 +268,7 @@ static int append_value(Statement *stmt, const SqlValue *value, SqlError *err, s
     return SQL_SUCCESS;
 }
 
+/* 값 종류를 보고 정수 파서와 문자열 파서 중 하나로 분기한다. */
 static int parse_value(Parser *parser, SqlValue *out, SqlError *err) {
     skip_whitespace(parser);
     memset(out, 0, sizeof(*out));
@@ -282,6 +286,7 @@ static int parse_value(Parser *parser, SqlValue *out, SqlError *err) {
     return SQL_FAILURE;
 }
 
+/* VALUES (...) 내부를 순서대로 읽어 가변 길이 배열로 축적한다. */
 static int parse_values_list(Parser *parser, Statement *stmt, SqlError *err) {
     int saw_value;
 
@@ -333,6 +338,7 @@ static int parse_values_list(Parser *parser, Statement *stmt, SqlError *err) {
     }
 }
 
+/* INSERT 문의 나머지 문법을 읽고 Statement를 채운다. */
 static int parse_insert(Parser *parser, Statement *stmt, SqlError *err) {
     stmt->type = STMT_INSERT;
 
@@ -352,6 +358,7 @@ static int parse_insert(Parser *parser, Statement *stmt, SqlError *err) {
     return parse_values_list(parser, stmt, err);
 }
 
+/* SELECT는 Phase 1에서 SELECT * FROM ... 형태만 허용한다. */
 static int parse_select(Parser *parser, Statement *stmt, SqlError *err) {
     stmt->type = STMT_SELECT;
 
@@ -369,6 +376,7 @@ static int parse_select(Parser *parser, Statement *stmt, SqlError *err) {
     return parse_qualified_name(parser, stmt, err);
 }
 
+/* Phase 1 파서의 진입점이다. 성공 시에만 완성된 AST를 호출자에게 넘긴다. */
 int parse_sql(const char *sql, Statement *out, SqlError *err) {
     Parser parser;
     Statement stmt;
@@ -420,6 +428,7 @@ int parse_sql(const char *sql, Statement *out, SqlError *err) {
         return SQL_FAILURE;
     }
 
+    /* 세미콜론 뒤에 남는 문자가 있으면 다중 문장으로 간주해 실패시킨다. */
     skip_whitespace(&parser);
     if (current_char(&parser) != ';') {
         statement_free(&stmt);

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,0 +1,443 @@
+#include "parse.h"
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct Parser {
+    const char *input;
+    size_t length;
+    size_t pos;
+} Parser;
+
+static int ascii_tolower(int ch) {
+    if (ch >= 'A' && ch <= 'Z') {
+        return ch - 'A' + 'a';
+    }
+
+    return ch;
+}
+
+static int is_identifier_start(char ch) {
+    return isalpha((unsigned char) ch) || ch == '_';
+}
+
+static int is_identifier_char(char ch) {
+    return isalnum((unsigned char) ch) || ch == '_';
+}
+
+static char current_char(const Parser *parser) {
+    if (parser->pos >= parser->length) {
+        return '\0';
+    }
+
+    return parser->input[parser->pos];
+}
+
+static void skip_whitespace(Parser *parser) {
+    while (parser->pos < parser->length &&
+           isspace((unsigned char) parser->input[parser->pos])) {
+        parser->pos++;
+    }
+}
+
+static char *copy_substring(const char *start, size_t length) {
+    char *buffer;
+
+    buffer = (char *) malloc(length + 1);
+    if (buffer == NULL) {
+        return NULL;
+    }
+
+    if (length > 0) {
+        memcpy(buffer, start, length);
+    }
+    buffer[length] = '\0';
+    return buffer;
+}
+
+static int match_keyword(Parser *parser, const char *keyword) {
+    size_t start;
+    size_t i;
+
+    start = parser->pos;
+    for (i = 0; keyword[i] != '\0'; ++i) {
+        if (start + i >= parser->length) {
+            return 0;
+        }
+
+        if (ascii_tolower((unsigned char) parser->input[start + i]) !=
+            ascii_tolower((unsigned char) keyword[i])) {
+            return 0;
+        }
+    }
+
+    if (start + i < parser->length &&
+        is_identifier_char(parser->input[start + i])) {
+        return 0;
+    }
+
+    parser->pos = start + i;
+    return 1;
+}
+
+static int expect_keyword(Parser *parser, const char *keyword, SqlError *err) {
+    size_t position;
+
+    skip_whitespace(parser);
+    position = parser->pos;
+
+    if (!match_keyword(parser, keyword)) {
+        sql_error_set(err, SQL_ERR_PARSE, position, "Expected keyword %s", keyword);
+        return SQL_FAILURE;
+    }
+
+    return SQL_SUCCESS;
+}
+
+static int parse_identifier(Parser *parser, char **out, SqlError *err) {
+    size_t start;
+    size_t length;
+    char *name;
+
+    skip_whitespace(parser);
+    start = parser->pos;
+
+    if (!is_identifier_start(current_char(parser))) {
+        sql_error_set(err, SQL_ERR_LEX, parser->pos, "Expected identifier");
+        return SQL_FAILURE;
+    }
+
+    parser->pos++;
+    while (is_identifier_char(current_char(parser))) {
+        parser->pos++;
+    }
+
+    length = parser->pos - start;
+    name = copy_substring(parser->input + start, length);
+    if (name == NULL) {
+        sql_error_set(err, SQL_ERR_MEMORY, parser->pos, "Out of memory while reading identifier");
+        return SQL_FAILURE;
+    }
+
+    *out = name;
+    return SQL_SUCCESS;
+}
+
+static int parse_qualified_name(Parser *parser, Statement *stmt, SqlError *err) {
+    char *first;
+    char *second;
+
+    first = NULL;
+    second = NULL;
+
+    if (parse_identifier(parser, &first, err) != SQL_SUCCESS) {
+        return SQL_FAILURE;
+    }
+
+    skip_whitespace(parser);
+    if (current_char(parser) == '.') {
+        parser->pos++;
+        if (parse_identifier(parser, &second, err) != SQL_SUCCESS) {
+            free(first);
+            return SQL_FAILURE;
+        }
+
+        stmt->schema = first;
+        stmt->table = second;
+        return SQL_SUCCESS;
+    }
+
+    stmt->table = first;
+    return SQL_SUCCESS;
+}
+
+static int consume_char(Parser *parser, char expected, SqlError *err) {
+    skip_whitespace(parser);
+    if (current_char(parser) != expected) {
+        sql_error_set(err, SQL_ERR_PARSE, parser->pos, "Expected '%c'", expected);
+        return SQL_FAILURE;
+    }
+
+    parser->pos++;
+    return SQL_SUCCESS;
+}
+
+static int parse_integer_value(Parser *parser, SqlValue *value, SqlError *err) {
+    size_t start;
+    char *buffer;
+    char *endptr;
+    long long parsed;
+
+    start = parser->pos;
+    if (current_char(parser) == '+' || current_char(parser) == '-') {
+        parser->pos++;
+    }
+
+    if (!isdigit((unsigned char) current_char(parser))) {
+        sql_error_set(err, SQL_ERR_LEX, start, "Expected integer literal");
+        return SQL_FAILURE;
+    }
+
+    while (isdigit((unsigned char) current_char(parser))) {
+        parser->pos++;
+    }
+
+    buffer = copy_substring(parser->input + start, parser->pos - start);
+    if (buffer == NULL) {
+        sql_error_set(err, SQL_ERR_MEMORY, parser->pos, "Out of memory while reading integer");
+        return SQL_FAILURE;
+    }
+
+    errno = 0;
+    parsed = strtoll(buffer, &endptr, 10);
+    if (errno == ERANGE || endptr == buffer || *endptr != '\0') {
+        free(buffer);
+        sql_error_set(err, SQL_ERR_LEX, start, "Invalid integer literal");
+        return SQL_FAILURE;
+    }
+
+    free(buffer);
+    value->type = SQL_VALUE_INT;
+    value->as.int_value = parsed;
+    return SQL_SUCCESS;
+}
+
+static int parse_string_value(Parser *parser, SqlValue *value, SqlError *err) {
+    size_t start;
+    size_t length;
+    char *buffer;
+
+    if (current_char(parser) != '\'') {
+        sql_error_set(err, SQL_ERR_LEX, parser->pos, "Expected string literal");
+        return SQL_FAILURE;
+    }
+
+    parser->pos++;
+    start = parser->pos;
+
+    while (parser->pos < parser->length && parser->input[parser->pos] != '\'') {
+        parser->pos++;
+    }
+
+    if (parser->pos >= parser->length) {
+        sql_error_set(err, SQL_ERR_LEX, start, "Unterminated string literal");
+        return SQL_FAILURE;
+    }
+
+    length = parser->pos - start;
+    buffer = copy_substring(parser->input + start, length);
+    if (buffer == NULL) {
+        sql_error_set(err, SQL_ERR_MEMORY, parser->pos, "Out of memory while reading string");
+        return SQL_FAILURE;
+    }
+
+    parser->pos++;
+    value->type = SQL_VALUE_STRING;
+    value->as.string_value = buffer;
+    return SQL_SUCCESS;
+}
+
+static void free_value(SqlValue *value) {
+    if (value == NULL) {
+        return;
+    }
+
+    if (value->type == SQL_VALUE_STRING) {
+        free(value->as.string_value);
+        value->as.string_value = NULL;
+    }
+}
+
+static int append_value(Statement *stmt, const SqlValue *value, SqlError *err, size_t position) {
+    SqlValue *expanded;
+
+    expanded = (SqlValue *) realloc(stmt->values, (stmt->value_count + 1) * sizeof(*stmt->values));
+    if (expanded == NULL) {
+        sql_error_set(err, SQL_ERR_MEMORY, position, "Out of memory while growing VALUES list");
+        return SQL_FAILURE;
+    }
+
+    stmt->values = expanded;
+    stmt->values[stmt->value_count] = *value;
+    stmt->value_count++;
+    return SQL_SUCCESS;
+}
+
+static int parse_value(Parser *parser, SqlValue *out, SqlError *err) {
+    skip_whitespace(parser);
+    memset(out, 0, sizeof(*out));
+
+    if (current_char(parser) == '\'') {
+        return parse_string_value(parser, out, err);
+    }
+
+    if (current_char(parser) == '+' || current_char(parser) == '-' ||
+        isdigit((unsigned char) current_char(parser))) {
+        return parse_integer_value(parser, out, err);
+    }
+
+    sql_error_set(err, SQL_ERR_LEX, parser->pos, "Expected integer or string literal");
+    return SQL_FAILURE;
+}
+
+static int parse_values_list(Parser *parser, Statement *stmt, SqlError *err) {
+    int saw_value;
+
+    if (consume_char(parser, '(', err) != SQL_SUCCESS) {
+        return SQL_FAILURE;
+    }
+
+    saw_value = 0;
+    while (1) {
+        SqlValue value;
+
+        skip_whitespace(parser);
+        if (current_char(parser) == ')') {
+            if (!saw_value) {
+                sql_error_set(err,
+                              SQL_ERR_UNSUPPORTED,
+                              parser->pos,
+                              "VALUES list must contain at least one literal");
+                return SQL_FAILURE;
+            }
+
+            parser->pos++;
+            return SQL_SUCCESS;
+        }
+
+        if (parse_value(parser, &value, err) != SQL_SUCCESS) {
+            return SQL_FAILURE;
+        }
+
+        if (append_value(stmt, &value, err, parser->pos) != SQL_SUCCESS) {
+            free_value(&value);
+            return SQL_FAILURE;
+        }
+
+        saw_value = 1;
+        skip_whitespace(parser);
+        if (current_char(parser) == ',') {
+            parser->pos++;
+            continue;
+        }
+
+        if (current_char(parser) == ')') {
+            parser->pos++;
+            return SQL_SUCCESS;
+        }
+
+        sql_error_set(err, SQL_ERR_PARSE, parser->pos, "Expected ',' or ')' in VALUES list");
+        return SQL_FAILURE;
+    }
+}
+
+static int parse_insert(Parser *parser, Statement *stmt, SqlError *err) {
+    stmt->type = STMT_INSERT;
+
+    if (expect_keyword(parser, "INTO", err) != SQL_SUCCESS) {
+        return SQL_FAILURE;
+    }
+
+    if (parse_qualified_name(parser, stmt, err) != SQL_SUCCESS) {
+        return SQL_FAILURE;
+    }
+
+    if (expect_keyword(parser, "VALUES", err) != SQL_SUCCESS) {
+        sql_error_set(err, SQL_ERR_PARSE, parser->pos, "Expected VALUES after INSERT target");
+        return SQL_FAILURE;
+    }
+
+    return parse_values_list(parser, stmt, err);
+}
+
+static int parse_select(Parser *parser, Statement *stmt, SqlError *err) {
+    stmt->type = STMT_SELECT;
+
+    skip_whitespace(parser);
+    if (current_char(parser) != '*') {
+        sql_error_set(err, SQL_ERR_UNSUPPORTED, parser->pos, "Only SELECT * is supported");
+        return SQL_FAILURE;
+    }
+    parser->pos++;
+
+    if (expect_keyword(parser, "FROM", err) != SQL_SUCCESS) {
+        return SQL_FAILURE;
+    }
+
+    return parse_qualified_name(parser, stmt, err);
+}
+
+int parse_sql(const char *sql, Statement *out, SqlError *err) {
+    Parser parser;
+    Statement stmt;
+    size_t first_non_space;
+
+    if (err == NULL) {
+        return SQL_FAILURE;
+    }
+
+    sql_error_clear(err);
+    if (sql == NULL || out == NULL) {
+        sql_error_set(err, SQL_ERR_ARGUMENT, 0, "SQL input and output statement are required");
+        return SQL_FAILURE;
+    }
+
+    statement_init(&stmt);
+
+    parser.input = sql;
+    parser.length = strlen(sql);
+    parser.pos = 0;
+
+    first_non_space = 0;
+    while (first_non_space < parser.length &&
+           isspace((unsigned char) sql[first_non_space])) {
+        first_non_space++;
+    }
+
+    if (first_non_space == parser.length) {
+        sql_error_set(err, SQL_ERR_PARSE, 0, "SQL input is empty");
+        return SQL_FAILURE;
+    }
+
+    skip_whitespace(&parser);
+    if (match_keyword(&parser, "INSERT")) {
+        if (parse_insert(&parser, &stmt, err) != SQL_SUCCESS) {
+            statement_free(&stmt);
+            return SQL_FAILURE;
+        }
+    } else if (match_keyword(&parser, "SELECT")) {
+        if (parse_select(&parser, &stmt, err) != SQL_SUCCESS) {
+            statement_free(&stmt);
+            return SQL_FAILURE;
+        }
+    } else {
+        sql_error_set(err,
+                      SQL_ERR_UNSUPPORTED,
+                      parser.pos,
+                      "Only INSERT and SELECT statements are supported");
+        return SQL_FAILURE;
+    }
+
+    skip_whitespace(&parser);
+    if (current_char(&parser) != ';') {
+        statement_free(&stmt);
+        sql_error_set(err, SQL_ERR_PARSE, parser.pos, "Expected ';' at end of statement");
+        return SQL_FAILURE;
+    }
+    parser.pos++;
+
+    skip_whitespace(&parser);
+    if (parser.pos != parser.length) {
+        statement_free(&stmt);
+        sql_error_set(err,
+                      SQL_ERR_UNSUPPORTED,
+                      parser.pos,
+                      "Only one SQL statement per file is allowed");
+        return SQL_FAILURE;
+    }
+
+    *out = stmt;
+    return SQL_SUCCESS;
+}

--- a/src/parser.c
+++ b/src/parser.c
@@ -2,6 +2,7 @@
 
 #include <ctype.h>
 #include <errno.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -254,9 +255,18 @@ static void free_value(SqlValue *value) {
 }
 
 static int append_value(Statement *stmt, const SqlValue *value, SqlError *err, size_t position) {
+    size_t new_count;
+    size_t new_size;
     SqlValue *expanded;
 
-    expanded = (SqlValue *) realloc(stmt->values, (stmt->value_count + 1) * sizeof(*stmt->values));
+    if (stmt->value_count >= SIZE_MAX / sizeof(*stmt->values)) {
+        sql_error_set(err, SQL_ERR_MEMORY, position, "VALUES list is too large to allocate safely");
+        return SQL_FAILURE;
+    }
+
+    new_count = stmt->value_count + 1;
+    new_size = new_count * sizeof(*stmt->values);
+    expanded = (SqlValue *) realloc(stmt->values, new_size);
     if (expanded == NULL) {
         sql_error_set(err, SQL_ERR_MEMORY, position, "Out of memory while growing VALUES list");
         return SQL_FAILURE;
@@ -288,29 +298,21 @@ static int parse_value(Parser *parser, SqlValue *out, SqlError *err) {
 
 /* VALUES (...) 내부를 순서대로 읽어 가변 길이 배열로 축적한다. */
 static int parse_values_list(Parser *parser, Statement *stmt, SqlError *err) {
-    int saw_value;
-
     if (consume_char(parser, '(', err) != SQL_SUCCESS) {
         return SQL_FAILURE;
     }
 
-    saw_value = 0;
+    skip_whitespace(parser);
+    if (current_char(parser) == ')') {
+        sql_error_set(err,
+                      SQL_ERR_UNSUPPORTED,
+                      parser->pos,
+                      "VALUES list must contain at least one literal");
+        return SQL_FAILURE;
+    }
+
     while (1) {
         SqlValue value;
-
-        skip_whitespace(parser);
-        if (current_char(parser) == ')') {
-            if (!saw_value) {
-                sql_error_set(err,
-                              SQL_ERR_UNSUPPORTED,
-                              parser->pos,
-                              "VALUES list must contain at least one literal");
-                return SQL_FAILURE;
-            }
-
-            parser->pos++;
-            return SQL_SUCCESS;
-        }
 
         if (parse_value(parser, &value, err) != SQL_SUCCESS) {
             return SQL_FAILURE;
@@ -321,16 +323,24 @@ static int parse_values_list(Parser *parser, Statement *stmt, SqlError *err) {
             return SQL_FAILURE;
         }
 
-        saw_value = 1;
         skip_whitespace(parser);
-        if (current_char(parser) == ',') {
-            parser->pos++;
-            continue;
-        }
-
         if (current_char(parser) == ')') {
             parser->pos++;
             return SQL_SUCCESS;
+        }
+
+        if (current_char(parser) == ',') {
+            parser->pos++;
+            skip_whitespace(parser);
+            if (current_char(parser) == ')') {
+                sql_error_set(err,
+                              SQL_ERR_PARSE,
+                              parser->pos,
+                              "Trailing comma is not allowed in VALUES list");
+                return SQL_FAILURE;
+            }
+
+            continue;
         }
 
         sql_error_set(err, SQL_ERR_PARSE, parser->pos, "Expected ',' or ')' in VALUES list");

--- a/src/sql_error.c
+++ b/src/sql_error.c
@@ -1,0 +1,58 @@
+#include "sql_error.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+
+void sql_error_clear(SqlError *err) {
+    if (err == NULL) {
+        return;
+    }
+
+    err->code = SQL_ERR_NONE;
+    err->position = 0;
+    err->message[0] = '\0';
+}
+
+void sql_error_set(SqlError *err, SqlErrorCode code, size_t position, const char *fmt, ...) {
+    va_list args;
+
+    if (err == NULL) {
+        return;
+    }
+
+    err->code = code;
+    err->position = position;
+
+    if (fmt == NULL) {
+        err->message[0] = '\0';
+        return;
+    }
+
+    va_start(args, fmt);
+    vsnprintf(err->message, sizeof(err->message), fmt, args);
+    va_end(args);
+    err->message[sizeof(err->message) - 1] = '\0';
+}
+
+const char *sql_error_code_name(SqlErrorCode code) {
+    switch (code) {
+        case SQL_ERR_NONE:
+            return "NONE";
+        case SQL_ERR_ARGUMENT:
+            return "ARGUMENT";
+        case SQL_ERR_IO:
+            return "IO";
+        case SQL_ERR_LEX:
+            return "LEX";
+        case SQL_ERR_PARSE:
+            return "PARSE";
+        case SQL_ERR_UNSUPPORTED:
+            return "UNSUPPORTED";
+        case SQL_ERR_MEMORY:
+            return "MEMORY";
+        case SQL_ERR_NOT_IMPLEMENTED:
+            return "NOT_IMPLEMENTED";
+        default:
+            return "UNKNOWN";
+    }
+}

--- a/src/sql_error.c
+++ b/src/sql_error.c
@@ -3,6 +3,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+/* 같은 SqlError 인스턴스를 여러 호출에서 재사용할 수 있게 초기화한다. */
 void sql_error_clear(SqlError *err) {
     if (err == NULL) {
         return;
@@ -13,6 +14,7 @@ void sql_error_clear(SqlError *err) {
     err->message[0] = '\0';
 }
 
+/* 모든 실패 지점을 같은 형식으로 기록하기 위한 공통 함수다. */
 void sql_error_set(SqlError *err, SqlErrorCode code, size_t position, const char *fmt, ...) {
     va_list args;
 

--- a/src/statement.c
+++ b/src/statement.c
@@ -1,0 +1,44 @@
+#include "sql_types.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+void statement_init(Statement *stmt) {
+    if (stmt == NULL) {
+        return;
+    }
+
+    memset(stmt, 0, sizeof(*stmt));
+}
+
+void statement_free(Statement *stmt) {
+    size_t i;
+
+    if (stmt == NULL) {
+        return;
+    }
+
+    free(stmt->schema);
+    free(stmt->table);
+
+    for (i = 0; i < stmt->value_count; ++i) {
+        if (stmt->values[i].type == SQL_VALUE_STRING) {
+            free(stmt->values[i].as.string_value);
+        }
+    }
+
+    free(stmt->values);
+    statement_init(stmt);
+}
+
+const char *statement_type_name(StatementType type) {
+    switch (type) {
+        case STMT_INSERT:
+            return "INSERT";
+        case STMT_SELECT:
+            return "SELECT";
+        case STMT_NONE:
+        default:
+            return "NONE";
+    }
+}

--- a/src/statement.c
+++ b/src/statement.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* NULL 안전하게 0으로 초기화해 호출자가 언제든 free 경로를 재사용할 수 있게 한다. */
 void statement_init(Statement *stmt) {
     if (stmt == NULL) {
         return;
@@ -11,6 +12,7 @@ void statement_init(Statement *stmt) {
     memset(stmt, 0, sizeof(*stmt));
 }
 
+/* Statement가 소유한 모든 힙 메모리를 한 곳에서 해제한다. */
 void statement_free(Statement *stmt) {
     size_t i;
 

--- a/src/storage_stub.c
+++ b/src/storage_stub.c
@@ -1,5 +1,6 @@
 #include "storage.h"
 
+/* 저장소 로직이 들어올 자리를 먼저 고정해 두기 위한 스텁이다. */
 int storage_append_row(const char *data_dir,
                        const char *schema,
                        const char *table,

--- a/src/storage_stub.c
+++ b/src/storage_stub.c
@@ -1,0 +1,24 @@
+#include "storage.h"
+
+int storage_append_row(const char *data_dir,
+                       const char *schema,
+                       const char *table,
+                       const SqlValue *values,
+                       size_t value_count,
+                       SqlError *err) {
+    (void) data_dir;
+    (void) schema;
+    (void) table;
+    (void) values;
+    (void) value_count;
+
+    if (err == NULL) {
+        return SQL_FAILURE;
+    }
+
+    sql_error_set(err,
+                  SQL_ERR_NOT_IMPLEMENTED,
+                  0,
+                  "storage_append_row is reserved for Phase 2");
+    return SQL_FAILURE;
+}

--- a/tests/test_parser.c
+++ b/tests/test_parser.c
@@ -108,6 +108,19 @@ static int test_fail_unterminated_string(void) {
     return 0;
 }
 
+static int test_fail_trailing_comma_in_values(void) {
+    const char *sql = "INSERT INTO users VALUES (1, 'alice',);";
+    Statement stmt;
+    SqlError err;
+
+    sql_error_clear(&err);
+    statement_init(&stmt);
+    CHECK(parse_sql(sql, &stmt, &err) == SQL_FAILURE);
+    CHECK(err.code == SQL_ERR_PARSE);
+    statement_free(&stmt);
+    return 0;
+}
+
 static int test_fail_multiple_statements(void) {
     const char *sql = "SELECT * FROM users; SELECT * FROM users;";
     Statement stmt;
@@ -145,6 +158,7 @@ int main(void) {
         { "fail_missing_semicolon", test_fail_missing_semicolon },
         { "fail_column_list", test_fail_column_list },
         { "fail_unterminated_string", test_fail_unterminated_string },
+        { "fail_trailing_comma_in_values", test_fail_trailing_comma_in_values },
         { "fail_multiple_statements", test_fail_multiple_statements },
         { "fail_where_clause", test_fail_where_clause }
     };

--- a/tests/test_parser.c
+++ b/tests/test_parser.c
@@ -1,0 +1,171 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "parse.h"
+#include "sql_error.h"
+#include "sql_types.h"
+
+#define CHECK(condition)                                                            \
+    do {                                                                            \
+        if (!(condition)) {                                                         \
+            fprintf(stderr, "Check failed: %s (line %d)\n", #condition, __LINE__);  \
+            return 1;                                                               \
+        }                                                                           \
+    } while (0)
+
+static int test_insert_simple(void) {
+    const char *sql = "INSERT INTO users VALUES (1, 'alice', 20);";
+    Statement stmt;
+    SqlError err;
+
+    sql_error_clear(&err);
+    statement_init(&stmt);
+    CHECK(parse_sql(sql, &stmt, &err) == SQL_SUCCESS);
+    CHECK(stmt.type == STMT_INSERT);
+    CHECK(stmt.schema == NULL);
+    CHECK(strcmp(stmt.table, "users") == 0);
+    CHECK(stmt.value_count == 3);
+    CHECK(stmt.values[0].type == SQL_VALUE_INT);
+    CHECK(stmt.values[0].as.int_value == 1);
+    CHECK(stmt.values[1].type == SQL_VALUE_STRING);
+    CHECK(strcmp(stmt.values[1].as.string_value, "alice") == 0);
+    CHECK(stmt.values[2].type == SQL_VALUE_INT);
+    CHECK(stmt.values[2].as.int_value == 20);
+    statement_free(&stmt);
+    return 0;
+}
+
+static int test_select_schema_with_whitespace(void) {
+    const char *sql = " \n SeLeCt   * \n FROM app . users \n ; ";
+    Statement stmt;
+    SqlError err;
+
+    sql_error_clear(&err);
+    statement_init(&stmt);
+    CHECK(parse_sql(sql, &stmt, &err) == SQL_SUCCESS);
+    CHECK(stmt.type == STMT_SELECT);
+    CHECK(strcmp(stmt.schema, "app") == 0);
+    CHECK(strcmp(stmt.table, "users") == 0);
+    CHECK(stmt.value_count == 0);
+    statement_free(&stmt);
+    return 0;
+}
+
+static int test_insert_negative_integer(void) {
+    const char *sql = "INSERT INTO audit.logs VALUES (-12, 'ok');";
+    Statement stmt;
+    SqlError err;
+
+    sql_error_clear(&err);
+    statement_init(&stmt);
+    CHECK(parse_sql(sql, &stmt, &err) == SQL_SUCCESS);
+    CHECK(stmt.type == STMT_INSERT);
+    CHECK(strcmp(stmt.schema, "audit") == 0);
+    CHECK(strcmp(stmt.table, "logs") == 0);
+    CHECK(stmt.value_count == 2);
+    CHECK(stmt.values[0].as.int_value == -12);
+    statement_free(&stmt);
+    return 0;
+}
+
+static int test_fail_missing_semicolon(void) {
+    const char *sql = "SELECT * FROM users";
+    Statement stmt;
+    SqlError err;
+
+    sql_error_clear(&err);
+    statement_init(&stmt);
+    CHECK(parse_sql(sql, &stmt, &err) == SQL_FAILURE);
+    CHECK(err.code == SQL_ERR_PARSE);
+    statement_free(&stmt);
+    return 0;
+}
+
+static int test_fail_column_list(void) {
+    const char *sql = "SELECT id FROM users;";
+    Statement stmt;
+    SqlError err;
+
+    sql_error_clear(&err);
+    statement_init(&stmt);
+    CHECK(parse_sql(sql, &stmt, &err) == SQL_FAILURE);
+    CHECK(err.code == SQL_ERR_UNSUPPORTED);
+    statement_free(&stmt);
+    return 0;
+}
+
+static int test_fail_unterminated_string(void) {
+    const char *sql = "INSERT INTO users VALUES (1, 'alice);";
+    Statement stmt;
+    SqlError err;
+
+    sql_error_clear(&err);
+    statement_init(&stmt);
+    CHECK(parse_sql(sql, &stmt, &err) == SQL_FAILURE);
+    CHECK(err.code == SQL_ERR_LEX);
+    statement_free(&stmt);
+    return 0;
+}
+
+static int test_fail_multiple_statements(void) {
+    const char *sql = "SELECT * FROM users; SELECT * FROM users;";
+    Statement stmt;
+    SqlError err;
+
+    sql_error_clear(&err);
+    statement_init(&stmt);
+    CHECK(parse_sql(sql, &stmt, &err) == SQL_FAILURE);
+    CHECK(err.code == SQL_ERR_UNSUPPORTED);
+    statement_free(&stmt);
+    return 0;
+}
+
+static int test_fail_where_clause(void) {
+    const char *sql = "SELECT * FROM users WHERE id = 1;";
+    Statement stmt;
+    SqlError err;
+
+    sql_error_clear(&err);
+    statement_init(&stmt);
+    CHECK(parse_sql(sql, &stmt, &err) == SQL_FAILURE);
+    CHECK(err.code == SQL_ERR_PARSE || err.code == SQL_ERR_UNSUPPORTED);
+    statement_free(&stmt);
+    return 0;
+}
+
+int main(void) {
+    struct {
+        const char *name;
+        int (*fn)(void);
+    } tests[] = {
+        { "insert_simple", test_insert_simple },
+        { "select_schema_with_whitespace", test_select_schema_with_whitespace },
+        { "insert_negative_integer", test_insert_negative_integer },
+        { "fail_missing_semicolon", test_fail_missing_semicolon },
+        { "fail_column_list", test_fail_column_list },
+        { "fail_unterminated_string", test_fail_unterminated_string },
+        { "fail_multiple_statements", test_fail_multiple_statements },
+        { "fail_where_clause", test_fail_where_clause }
+    };
+    size_t i;
+    int failures;
+
+    failures = 0;
+    for (i = 0; i < sizeof(tests) / sizeof(tests[0]); ++i) {
+        if (tests[i].fn() != 0) {
+            fprintf(stderr, "FAILED: %s\n", tests[i].name);
+            failures++;
+        } else {
+            printf("PASSED: %s\n", tests[i].name);
+        }
+    }
+
+    if (failures != 0) {
+        fprintf(stderr, "Parser tests failed: %d\n", failures);
+        return EXIT_FAILURE;
+    }
+
+    printf("All parser tests passed.\n");
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## 요약
Phase 1 범위의 미니 SQL Processor 초안을 추가하고 parser 중심 구조를 정리했습니다.

## 변경 사항
- parser, statement, sql_error, CLI와 execute/storage stub 구조 추가
- parser 테스트와 sample query/data 추가
- README, Agents, PHASE1_IMPLEMENTATION_NOTES 문서 보강
- Windows Dev-Cpp MinGW 기준 직접 빌드 및 실행 검증 수행

## 테스트
- `C:\Program Files (x86)\Dev-Cpp\MinGW64\bin\gcc.exe`로 `sql_processor.exe` 빌드
- `C:\Program Files (x86)\Dev-Cpp\MinGW64\bin\gcc.exe`로 `test_parser.exe` 빌드
- `test_parser.exe` 실행 성공
- `sql_processor.exe queries\insert_users.sql` 실행 성공
- `sql_processor.exe queries\select_users.sql` 실행 성공

## 비고
- `mingw32-make`는 현재 한글 경로에서 `readdir: Invalid argument`로 실패했습니다.
- MinGW/MSVCRT 조합으로 `printf` 길이 지정자 관련 pedantic 경고가 남아 있습니다.

Closes #1